### PR TITLE
Restrict the projection selector to locally-owned nodes

### DIFF
--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -926,7 +926,8 @@ LowMachEquationSystem::project_nodal_velocity()
     using MeshIndex = Traits::MeshIndex;
     const stk::mesh::Selector sel =
       ((!stk::mesh::selectUnion(momentumEqSys_->notProjectedPart_)) &
-       stk::mesh::selectField(*continuityEqSys_->dpdx_));
+       stk::mesh::selectField(*continuityEqSys_->dpdx_) &
+       realm_.meta_data().locally_owned_part());
     kynema_ugf_ngp::run_entity_algorithm(
       "nodal_velocity_projection", ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const MeshIndex& mi) {


### PR DESCRIPTION
## Summary

This avoids the FPE in SSTWallHumpEdge.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
