### PR TITLE
Change FMB - FSI algorithm to perform structural time step first

### DIFF
--- a/include/aero/FMBContainer.h
+++ b/include/aero/FMBContainer.h
@@ -28,7 +28,7 @@ public:
   void init(double currentTime, double restartFrequency);
   void update_displacements(
     const double currentTime, const bool updateCurCoords = true);
-  void predict_model_time_step(const double /*currentTime*/);
+  void map_loads(const double /*currentTime*/);
   void advance_model_time_step(const double /*currentTime*/, const double);
 
   bool is_active() { return has_six_dof(); }

--- a/include/aero/FMBContainer.h
+++ b/include/aero/FMBContainer.h
@@ -28,8 +28,9 @@ public:
   void init(double currentTime, double restartFrequency);
   void update_displacements(
     const double currentTime, const bool updateCurCoords = true);
-  void map_loads(const double /*currentTime*/);
-  void advance_model_time_step(const double /*currentTime*/, const double);
+  void map_loads();
+  void advance_struct_time_step(const double /*currentTime*/, const double);
+  void finalize_struct_timestep();
 
   bool is_active() { return has_six_dof(); }
   bool has_six_dof() { return sixDof_ != nullptr; }

--- a/include/aero/fmb/KynemaFMBBase.h
+++ b/include/aero/fmb/KynemaFMBBase.h
@@ -47,7 +47,7 @@ public:
   virtual void
   advance_struct_timestep(const double currentTime, const double dT) = 0;
 
-  virtual void map_loads(const double currentTime) = 0;
+  virtual void map_loads() = 0;
 
   void map_loads_point(PointMass& point);
 

--- a/include/aero/fmb/KynemaFMBSixDof.h
+++ b/include/aero/fmb/KynemaFMBSixDof.h
@@ -21,7 +21,6 @@ namespace sierra {
 
 namespace kynema_ugf {
 
-
 struct Tether
 {
   std::array<double, 3> fairlead_position = {0.0, 0.0, 0.0};
@@ -50,10 +49,11 @@ struct PointMassInterface
   int number_of_nonlinear_iterations = 5;
   double rho_inf{0.0};
 
-  enum lts { NM1 = 0, N = 1, NP1 = 2};
-  std::array<std::array<double, 6>,3> loads = {std::array<double, 6>{0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-                                    std::array<double, 6>{0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-                                    std::array<double, 6>{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
+  enum lts { NM1 = 0, N = 1, NP1 = 2 };
+  std::array<std::array<double, 6>, 3> loads = {
+    std::array<double, 6>{0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+    std::array<double, 6>{0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+    std::array<double, 6>{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
 };
 
 class KynemaFMBSixDof : public KynemaFMBBase

--- a/include/aero/fmb/KynemaFMBSixDof.h
+++ b/include/aero/fmb/KynemaFMBSixDof.h
@@ -21,6 +21,7 @@ namespace sierra {
 
 namespace kynema_ugf {
 
+
 struct Tether
 {
   std::array<double, 3> fairlead_position = {0.0, 0.0, 0.0};
@@ -48,6 +49,11 @@ struct PointMassInterface
   std::string output_file_name = "";
   int number_of_nonlinear_iterations = 5;
   double rho_inf{0.0};
+
+  enum lts { NM1 = 0, N = 1, NP1 = 2};
+  std::array<std::array<double, 6>,3> loads = {std::array<double, 6>{0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                                    std::array<double, 6>{0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                                    std::array<double, 6>{0.0, 0.0, 0.0, 0.0, 0.0, 0.0}};
 };
 
 class KynemaFMBSixDof : public KynemaFMBBase
@@ -65,7 +71,13 @@ public:
 
   void advance_struct_timestep(const double, const double) override;
 
-  void map_loads(const double) override;
+  void finalize_struct_timestep();
+
+  void predict_loads();
+
+  void send_loads(const double curTime);
+
+  void map_loads() override;
 
   stk::mesh::PartVector get_mesh_blocks() const override
   {
@@ -92,7 +104,6 @@ private:
 
   void load(const YAML::Node&);
 
-  void send_loads(const double curTime);
   void timer_start(std::pair<double, double>& timer);
   void timer_stop(std::pair<double, double>& timer);
 

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1896,8 +1896,7 @@ Realm::update_geometry_due_to_mesh_motion()
 
 #ifdef KYNEMA_UGF_USES_KYNEMA_FMB
     if (fmbModels_->is_active()) {
-      fmbModels_->map_loads(get_current_time());
-      fmbModels_->advance_model_time_step(get_current_time(), get_time_step_size());
+      fmbModels_->advance_struct_time_step(get_current_time(), get_time_step());
       fmbModels_->update_displacements(get_current_time());
     }
 #endif
@@ -4762,6 +4761,13 @@ Realm::post_converged_work()
     aeroModels_->advance_model_time_step(
       get_current_time(), timeIntegrator_->get_time_step());
   }
+
+#ifdef KYNEMA_UGF_USES_KYNEMA_FMB
+  if (fmbModels_->is_active()) {
+    fmbModels_->map_loads();
+    fmbModels_->finalize_struct_timestep();
+  }
+#endif
 
   // FIXME: Consider a unified collection of post processing work
   if (NULL != solutionNormPostProcessing_)

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1896,6 +1896,8 @@ Realm::update_geometry_due_to_mesh_motion()
 
 #ifdef KYNEMA_UGF_USES_KYNEMA_FMB
     if (fmbModels_->is_active()) {
+      fmbModels_->map_loads(get_current_time());
+      fmbModels_->advance_model_time_step(get_current_time(), get_time_step_size());
       fmbModels_->update_displacements(get_current_time());
     }
 #endif
@@ -4649,13 +4651,6 @@ Realm::process_multi_physics_transfer(bool initCall)
         << "Aero models - Predict model time step" << std::endl;
       aeroModels_->predict_model_time_step(get_current_time());
     }
-#ifdef KYNEMA_UGF_USES_KYNEMA_FMB
-    if (fmbModels_->is_active()) {
-      KynemaUGFEnv::self().kynema_ugfOutputP0()
-        << "Kynema-FMB models - Predict model time step" << std::endl;
-      fmbModels_->predict_model_time_step(get_current_time());
-    }
-#endif
   }
 
   /* if (openfast_ != NULL) */
@@ -4767,15 +4762,6 @@ Realm::post_converged_work()
     aeroModels_->advance_model_time_step(
       get_current_time(), timeIntegrator_->get_time_step());
   }
-
-#ifdef KYNEMA_UGF_USES_KYNEMA_FMB
-  if (fmbModels_->is_active()) {
-    KynemaUGFEnv::self().kynema_ugfOutputP0()
-      << "Kynema-FMB models - advance model timestep" << std::endl;
-    fmbModels_->advance_model_time_step(
-      get_current_time(), timeIntegrator_->get_time_step());
-  }
-#endif
 
   // FIXME: Consider a unified collection of post processing work
   if (NULL != solutionNormPostProcessing_)

--- a/src/aero/FMBContainer.C
+++ b/src/aero/FMBContainer.C
@@ -43,18 +43,28 @@ FMBContainer::update_displacements(const double currentTime, bool updateCC)
 }
 
 void
-FMBContainer::map_loads(const double currentTime)
+FMBContainer::map_loads()
 {
   if (has_six_dof()) {
-    sixDof_->map_loads(currentTime);
+    sixDof_->map_loads();
   }
 }
 
 void
-FMBContainer::advance_model_time_step(const double currentTime, const double dT)
+FMBContainer::advance_struct_time_step(const double currentTime, const double dT)
 {
   if (has_six_dof()) {
+    sixDof_->predict_loads();
+    sixDof_->send_loads(currentTime);
     sixDof_->advance_struct_timestep(currentTime, dT);
+  }
+}
+
+void
+FMBContainer::finalize_struct_timestep()
+{
+  if (has_six_dof()) {
+    sixDof_->finalize_struct_timestep();
   }
 }
 

--- a/src/aero/FMBContainer.C
+++ b/src/aero/FMBContainer.C
@@ -51,7 +51,8 @@ FMBContainer::map_loads()
 }
 
 void
-FMBContainer::advance_struct_time_step(const double currentTime, const double dT)
+FMBContainer::advance_struct_time_step(
+  const double currentTime, const double dT)
 {
   if (has_six_dof()) {
     sixDof_->predict_loads();

--- a/src/aero/FMBContainer.C
+++ b/src/aero/FMBContainer.C
@@ -43,7 +43,7 @@ FMBContainer::update_displacements(const double currentTime, bool updateCC)
 }
 
 void
-FMBContainer::predict_model_time_step(const double currentTime)
+FMBContainer::map_loads(const double currentTime)
 {
   if (has_six_dof()) {
     sixDof_->map_loads(currentTime);

--- a/src/aero/fmb/KynemaFMBSixDof.C
+++ b/src/aero/fmb/KynemaFMBSixDof.C
@@ -472,11 +472,8 @@ KynemaFMBSixDof::send_loads(const double)
   for (int i = 0; i < (int)point_bodies_.size(); ++i) {
     auto& iface = point_interfaces_[i];
     auto& loads = iface.kynema_interface->turbine.floating_platform.node.loads;
-    for (int idim = 0; idim < 6; ++idim) {
-      loads[idim] = 0.5 * (1.0 - iface.rho_inf) * iface.loads[iface.lts::NP1][idim] +
-                    0.5 * (1.0 - iface.rho_inf) * loads[idim] +
-                    loads[idim] * iface.rho_inf;      
-    }
+    for (int idim = 0; idim < 6; ++idim)
+      loads[idim] = iface.loads[iface.lts::NP1][idim];
   }
 }
 

--- a/src/aero/fmb/KynemaFMBSixDof.C
+++ b/src/aero/fmb/KynemaFMBSixDof.C
@@ -452,8 +452,7 @@ KynemaFMBSixDof::map_loads()
   }
 }
 
-
-void 
+void
 KynemaFMBSixDof::predict_loads()
 {
   for (int i = 0; i < (int)point_bodies_.size(); ++i) {
@@ -477,7 +476,8 @@ KynemaFMBSixDof::send_loads(const double)
   }
 }
 
-void KynemaFMBSixDof::finalize_struct_timestep()
+void
+KynemaFMBSixDof::finalize_struct_timestep()
 {
   for (int i = 0; i < (int)point_bodies_.size(); ++i) {
     auto& iface = point_interfaces_[i];
@@ -489,6 +489,5 @@ void KynemaFMBSixDof::finalize_struct_timestep()
 }
 
 } // namespace kynema_ugf
-
 
 } // namespace sierra

--- a/src/aero/fmb/KynemaFMBSixDof.C
+++ b/src/aero/fmb/KynemaFMBSixDof.C
@@ -439,22 +439,59 @@ KynemaFMBSixDof::map_displacements(double current_time, bool updateCurCoor)
 }
 
 void
-KynemaFMBSixDof::map_loads(const double)
+KynemaFMBSixDof::map_loads()
 {
   for (int i = 0; i < (int)point_bodies_.size(); ++i) {
     map_loads_point(point_bodies_[i]);
 
     auto& forces_and_moments = point_bodies_[i].p_data.loads;
     auto& iface = point_interfaces_[i];
+    for (int idim = 0; idim < 6; ++idim) {
+      iface.loads[iface.lts::NP1][idim] = forces_and_moments[idim];
+    }
+  }
+}
+
+
+void 
+KynemaFMBSixDof::predict_loads()
+{
+  for (int i = 0; i < (int)point_bodies_.size(); ++i) {
+    auto& iface = point_interfaces_[i];
+    for (int idim = 0; idim < 6; ++idim) {
+      iface.loads[iface.lts::NP1][idim] =
+        2.0 * iface.loads[iface.lts::N][idim] -
+        iface.loads[iface.lts::NM1][idim];
+    }
+  }
+}
+
+void
+KynemaFMBSixDof::send_loads(const double)
+{
+  for (int i = 0; i < (int)point_bodies_.size(); ++i) {
+    auto& iface = point_interfaces_[i];
     auto& loads = iface.kynema_interface->turbine.floating_platform.node.loads;
     for (int idim = 0; idim < 6; ++idim) {
-      loads[idim] = 0.5 * (1.0 - iface.rho_inf) * forces_and_moments[idim] +
+      loads[idim] = 0.5 * (1.0 - iface.rho_inf) * iface.loads[iface.lts::NP1][idim] +
                     0.5 * (1.0 - iface.rho_inf) * loads[idim] +
-                    loads[idim] * iface.rho_inf;
+                    loads[idim] * iface.rho_inf;      
+    }
+  }
+}
+
+void KynemaFMBSixDof::finalize_struct_timestep()
+{
+  for (int i = 0; i < (int)point_bodies_.size(); ++i) {
+    auto& iface = point_interfaces_[i];
+    for (int idim = 0; idim < 6; ++idim) {
+      iface.loads[iface.lts::NM1][idim] = iface.loads[iface.lts::N][idim];
+      iface.loads[iface.lts::N][idim] = iface.loads[iface.lts::NP1][idim];
     }
   }
 }
 
 } // namespace kynema_ugf
+
 
 } // namespace sierra


### PR DESCRIPTION
## Summary

Change FMB - FSI algorithm to perform structural time step first. Draft PR. Do not merge.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe):


The documentation for FSI in Kynema-FMB suggests performing the structural model update first and then doing the CFD time step. Technically, we must also do the predictor for the forces being sent to FMB, but that's a discussion to be had later.

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
