### PR TITLE
Address FPE in nodal velocity projection

### DIFF
--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -892,15 +892,13 @@ LowMachEquationSystem::project_nodal_velocity()
   //==========================================================
   {
     const auto& fieldMgr = realm_.ngp_field_manager();
+    auto& uTmp = fieldMgr.get_field<double>(
+      momentumEqSys_->uTmp_->mesh_meta_data_ordinal());
+    auto& dpdx = fieldMgr.get_field<double>(
+      continuityEqSys_->dpdx_->mesh_meta_data_ordinal());
     const stk::mesh::Selector sel =
       stk::mesh::selectField(*continuityEqSys_->dpdx_);
-    kynema_ugf_ngp::field_copy(
-      ngpMesh, sel,
-      fieldMgr.get_field<double>(
-        momentumEqSys_->uTmp_->mesh_meta_data_ordinal()),
-      fieldMgr.get_field<double>(
-        continuityEqSys_->dpdx_->mesh_meta_data_ordinal()),
-      nDim);
+    kynema_ugf_ngp::field_copy(ngpMesh, sel, uTmp, dpdx, nDim);
   }
 
   //==========================================================
@@ -908,51 +906,29 @@ LowMachEquationSystem::project_nodal_velocity()
   //==========================================================
   continuityEqSys_->compute_projected_nodal_gradient();
 
-  // NOTE: re-acquire field handles AFTER the PNG update; handles obtained
+  // NOTE: re-acquire field references AFTER the PNG update; handles obtained
   // beforehand may be invalidated by field-data reallocation inside
   // compute_projected_nodal_gradient() (e.g. when projected_timescale_type is
-  // momentum_diag_inv with a periodic boundary).
-  //
-  // sync_to_device() may itself reallocate the internal NgpField object, so
-  // we perform all syncs via temporary references and then re-acquire
-  // by-value copies for the Kokkos lambda captures; a captured `auto&`
-  // reference would become dangling if reallocation occurs during sync.
-  {
-    const auto& fieldMgr = realm_.ngp_field_manager();
-    fieldMgr.get_field<double>(momentumEqSys_->uTmp_->mesh_meta_data_ordinal())
-      .sync_to_device();
-    fieldMgr
-      .get_field<double>(continuityEqSys_->dpdx_->mesh_meta_data_ordinal())
-      .sync_to_device();
-    fieldMgr
-      .get_field<double>(
-        momentumEqSys_->get_diagonal_field()->mesh_meta_data_ordinal())
-      .sync_to_device();
-    fieldMgr
-      .get_field<double>(
-        momentumEqSys_->velocity_->field_of_state(stk::mesh::StateNP1)
-          .mesh_meta_data_ordinal())
-      .sync_to_device();
-    fieldMgr
-      .get_field<double>(
-        density_->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal())
-      .sync_to_device();
-  }
-
-  // Re-acquire fresh by-value copies after all syncs are complete; these are
-  // safe to capture in the Kokkos lambdas below.
+  // momentum_diag_inv with a periodic boundary), causing a stale-pointer
+  // SIGFPE in the Kokkos lambdas below.
   const auto& fieldMgr = realm_.ngp_field_manager();
-  auto uTmp = fieldMgr.get_field<double>(
+  auto& uTmp = fieldMgr.get_field<double>(
     momentumEqSys_->uTmp_->mesh_meta_data_ordinal());
-  auto dpdx = fieldMgr.get_field<double>(
+  auto& dpdx = fieldMgr.get_field<double>(
     continuityEqSys_->dpdx_->mesh_meta_data_ordinal());
-  auto Udiag = fieldMgr.get_field<double>(
+  auto& Udiag = fieldMgr.get_field<double>(
     momentumEqSys_->get_diagonal_field()->mesh_meta_data_ordinal());
-  auto velNp1 = fieldMgr.get_field<double>(
+  auto& velNp1 = fieldMgr.get_field<double>(
     momentumEqSys_->velocity_->field_of_state(stk::mesh::StateNP1)
       .mesh_meta_data_ordinal());
-  auto rhoNp1 = fieldMgr.get_field<double>(
+  auto& rhoNp1 = fieldMgr.get_field<double>(
     density_->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal());
+
+  uTmp.sync_to_device();
+  dpdx.sync_to_device();
+  Udiag.sync_to_device();
+  velNp1.sync_to_device();
+  rhoNp1.sync_to_device();
 
   //==========================================================
   // project u, u^n+1 = u^k+1 - dt/rho*(Gjp^N+1 - uTmp);

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -933,6 +933,17 @@ LowMachEquationSystem::project_nodal_velocity()
   //==========================================================
   // project u, u^n+1 = u^k+1 - dt/rho*(Gjp^N+1 - uTmp);
   //==========================================================
+  // When using TSCALE_UDIAGINV, Udiag is assembled from the momentum-system
+  // diagonal; slave/halo/periodic nodes excluded from that assembly retain the
+  // zero initialisation value set before the solve.  Guard against the
+  // resulting divide-by-zero by clamping Udiag to the default timescale floor
+  // (gamma1/dt) for those nodes.  dt > 0 here because
+  // project_nodal_velocity() is only called from solve_and_update() after the
+  // time integrator has set a valid time step.
+  const double projTimeScale =
+    realm_.get_gamma1() / realm_.get_time_step();
+  const bool extractDiag =
+    (realm_.solutionOptions_->tscaleType_ == TSCALE_UDIAGINV);
   {
     using Traits = kynema_ugf_ngp::NGPMeshTraits<>;
     using MeshIndex = Traits::MeshIndex;
@@ -942,8 +953,12 @@ LowMachEquationSystem::project_nodal_velocity()
     kynema_ugf_ngp::run_entity_algorithm(
       "nodal_velocity_projection", ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const MeshIndex& mi) {
-        // Scaling factor
-        const double fac = 1.0 / (rhoNp1.get(mi, 0) * Udiag.get(mi, 0));
+        // Clamp Udiag to projTimeScale when using the diagonal timescale to
+        // guard against zero values on excluded (slave/halo/periodic) nodes.
+        const double udiag = extractDiag
+                               ? Kokkos::max(Udiag.get(mi, 0), projTimeScale)
+                               : Udiag.get(mi, 0);
+        const double fac = 1.0 / (rhoNp1.get(mi, 0) * udiag);
         // Projection step
         for (int d = 0; d < nDim; ++d) {
           velNp1.get(mi, d) -= fac * (dpdx.get(mi, d) - uTmp.get(mi, d));
@@ -954,8 +969,10 @@ LowMachEquationSystem::project_nodal_velocity()
     kynema_ugf_ngp::run_entity_algorithm(
       "nodal_velocity_projection_strongX", ngpMesh, stk::topology::NODE_RANK,
       selX, KOKKOS_LAMBDA(const MeshIndex& mi) {
-        // Scaling factor
-        const double fac = 1.0 / (rhoNp1.get(mi, 0) * Udiag.get(mi, 0));
+        const double udiag = extractDiag
+                               ? Kokkos::max(Udiag.get(mi, 0), projTimeScale)
+                               : Udiag.get(mi, 0);
+        const double fac = 1.0 / (rhoNp1.get(mi, 0) * udiag);
         //  undo Projection step
         velNp1.get(mi, 0) += fac * (dpdx.get(mi, 0) - uTmp.get(mi, 0));
       });
@@ -964,8 +981,10 @@ LowMachEquationSystem::project_nodal_velocity()
     kynema_ugf_ngp::run_entity_algorithm(
       "nodal_velocity_project_strongY", ngpMesh, stk::topology::NODE_RANK, selY,
       KOKKOS_LAMBDA(const MeshIndex& mi) {
-        // Scaling factor
-        const double fac = 1.0 / (rhoNp1.get(mi, 0) * Udiag.get(mi, 0));
+        const double udiag = extractDiag
+                               ? Kokkos::max(Udiag.get(mi, 0), projTimeScale)
+                               : Udiag.get(mi, 0);
+        const double fac = 1.0 / (rhoNp1.get(mi, 0) * udiag);
         //  undo Projection step
         velNp1.get(mi, 1) += fac * (dpdx.get(mi, 1) - uTmp.get(mi, 1));
       });
@@ -975,8 +994,10 @@ LowMachEquationSystem::project_nodal_velocity()
       kynema_ugf_ngp::run_entity_algorithm(
         "nodal_velocity_projection_strongZ", ngpMesh, stk::topology::NODE_RANK,
         selZ, KOKKOS_LAMBDA(const MeshIndex& mi) {
-          // Scaling factor
-          const double fac = 1.0 / (rhoNp1.get(mi, 0) * Udiag.get(mi, 0));
+          const double udiag = extractDiag
+                                 ? Kokkos::max(Udiag.get(mi, 0), projTimeScale)
+                                 : Udiag.get(mi, 0);
+          const double fac = 1.0 / (rhoNp1.get(mi, 0) * udiag);
           //  undo Projection step
           velNp1.get(mi, 2) += fac * (dpdx.get(mi, 2) - uTmp.get(mi, 2));
         });

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -892,13 +892,15 @@ LowMachEquationSystem::project_nodal_velocity()
   //==========================================================
   {
     const auto& fieldMgr = realm_.ngp_field_manager();
-    auto& uTmp = fieldMgr.get_field<double>(
-      momentumEqSys_->uTmp_->mesh_meta_data_ordinal());
-    auto& dpdx = fieldMgr.get_field<double>(
-      continuityEqSys_->dpdx_->mesh_meta_data_ordinal());
     const stk::mesh::Selector sel =
       stk::mesh::selectField(*continuityEqSys_->dpdx_);
-    kynema_ugf_ngp::field_copy(ngpMesh, sel, uTmp, dpdx, nDim);
+    kynema_ugf_ngp::field_copy(
+      ngpMesh, sel,
+      fieldMgr.get_field<double>(
+        momentumEqSys_->uTmp_->mesh_meta_data_ordinal()),
+      fieldMgr.get_field<double>(
+        continuityEqSys_->dpdx_->mesh_meta_data_ordinal()),
+      nDim);
   }
 
   //==========================================================
@@ -906,29 +908,51 @@ LowMachEquationSystem::project_nodal_velocity()
   //==========================================================
   continuityEqSys_->compute_projected_nodal_gradient();
 
-  // NOTE: re-acquire field references AFTER the PNG update; handles obtained
+  // NOTE: re-acquire field handles AFTER the PNG update; handles obtained
   // beforehand may be invalidated by field-data reallocation inside
   // compute_projected_nodal_gradient() (e.g. when projected_timescale_type is
-  // momentum_diag_inv with a periodic boundary), causing a stale-pointer
-  // SIGFPE in the Kokkos lambdas below.
+  // momentum_diag_inv with a periodic boundary).
+  //
+  // sync_to_device() may itself reallocate the internal NgpField object, so
+  // we perform all syncs via temporary references and then re-acquire
+  // by-value copies for the Kokkos lambda captures; a captured `auto&`
+  // reference would become dangling if reallocation occurs during sync.
+  {
+    const auto& fieldMgr = realm_.ngp_field_manager();
+    fieldMgr.get_field<double>(momentumEqSys_->uTmp_->mesh_meta_data_ordinal())
+      .sync_to_device();
+    fieldMgr
+      .get_field<double>(continuityEqSys_->dpdx_->mesh_meta_data_ordinal())
+      .sync_to_device();
+    fieldMgr
+      .get_field<double>(
+        momentumEqSys_->get_diagonal_field()->mesh_meta_data_ordinal())
+      .sync_to_device();
+    fieldMgr
+      .get_field<double>(
+        momentumEqSys_->velocity_->field_of_state(stk::mesh::StateNP1)
+          .mesh_meta_data_ordinal())
+      .sync_to_device();
+    fieldMgr
+      .get_field<double>(
+        density_->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal())
+      .sync_to_device();
+  }
+
+  // Re-acquire fresh by-value copies after all syncs are complete; these are
+  // safe to capture in the Kokkos lambdas below.
   const auto& fieldMgr = realm_.ngp_field_manager();
-  auto& uTmp = fieldMgr.get_field<double>(
+  auto uTmp = fieldMgr.get_field<double>(
     momentumEqSys_->uTmp_->mesh_meta_data_ordinal());
-  auto& dpdx = fieldMgr.get_field<double>(
+  auto dpdx = fieldMgr.get_field<double>(
     continuityEqSys_->dpdx_->mesh_meta_data_ordinal());
-  auto& Udiag = fieldMgr.get_field<double>(
+  auto Udiag = fieldMgr.get_field<double>(
     momentumEqSys_->get_diagonal_field()->mesh_meta_data_ordinal());
-  auto& velNp1 = fieldMgr.get_field<double>(
+  auto velNp1 = fieldMgr.get_field<double>(
     momentumEqSys_->velocity_->field_of_state(stk::mesh::StateNP1)
       .mesh_meta_data_ordinal());
-  auto& rhoNp1 = fieldMgr.get_field<double>(
+  auto rhoNp1 = fieldMgr.get_field<double>(
     density_->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal());
-
-  uTmp.sync_to_device();
-  dpdx.sync_to_device();
-  Udiag.sync_to_device();
-  velNp1.sync_to_device();
-  rhoNp1.sync_to_device();
 
   //==========================================================
   // project u, u^n+1 = u^k+1 - dt/rho*(Gjp^N+1 - uTmp);

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -936,10 +936,11 @@ LowMachEquationSystem::project_nodal_velocity()
   // When using TSCALE_UDIAGINV, Udiag is assembled from the momentum-system
   // diagonal; slave/halo/periodic nodes excluded from that assembly retain the
   // zero initialisation value set before the solve.  Guard against the
-  // resulting divide-by-zero by clamping Udiag to the default timescale floor
-  // (gamma1/dt) for those nodes.  dt > 0 here because
-  // project_nodal_velocity() is only called from solve_and_update() after the
-  // time integrator has set a valid time step.
+  // resulting divide-by-zero by substituting the default timescale
+  // (gamma1/dt) only for those zero-valued nodes, leaving all other nodes
+  // numerically unchanged.  dt > 0 here because project_nodal_velocity() is
+  // only called from solve_and_update() after the time integrator has set a
+  // valid time step.
   const double projTimeScale =
     realm_.get_gamma1() / realm_.get_time_step();
   const bool extractDiag =
@@ -953,11 +954,11 @@ LowMachEquationSystem::project_nodal_velocity()
     kynema_ugf_ngp::run_entity_algorithm(
       "nodal_velocity_projection", ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const MeshIndex& mi) {
-        // Clamp Udiag to projTimeScale when using the diagonal timescale to
-        // guard against zero values on excluded (slave/halo/periodic) nodes.
-        const double udiag = extractDiag
-                               ? Kokkos::max(Udiag.get(mi, 0), projTimeScale)
-                               : Udiag.get(mi, 0);
+        // Substitute projTimeScale only where the assembled diagonal is zero
+        // (excluded slave/halo/periodic nodes) to avoid divide-by-zero.
+        const double udiagRaw = Udiag.get(mi, 0);
+        const double udiag =
+          (extractDiag && udiagRaw == 0.0) ? projTimeScale : udiagRaw;
         const double fac = 1.0 / (rhoNp1.get(mi, 0) * udiag);
         // Projection step
         for (int d = 0; d < nDim; ++d) {
@@ -969,9 +970,9 @@ LowMachEquationSystem::project_nodal_velocity()
     kynema_ugf_ngp::run_entity_algorithm(
       "nodal_velocity_projection_strongX", ngpMesh, stk::topology::NODE_RANK,
       selX, KOKKOS_LAMBDA(const MeshIndex& mi) {
-        const double udiag = extractDiag
-                               ? Kokkos::max(Udiag.get(mi, 0), projTimeScale)
-                               : Udiag.get(mi, 0);
+        const double udiagRaw = Udiag.get(mi, 0);
+        const double udiag =
+          (extractDiag && udiagRaw == 0.0) ? projTimeScale : udiagRaw;
         const double fac = 1.0 / (rhoNp1.get(mi, 0) * udiag);
         //  undo Projection step
         velNp1.get(mi, 0) += fac * (dpdx.get(mi, 0) - uTmp.get(mi, 0));
@@ -981,9 +982,9 @@ LowMachEquationSystem::project_nodal_velocity()
     kynema_ugf_ngp::run_entity_algorithm(
       "nodal_velocity_project_strongY", ngpMesh, stk::topology::NODE_RANK, selY,
       KOKKOS_LAMBDA(const MeshIndex& mi) {
-        const double udiag = extractDiag
-                               ? Kokkos::max(Udiag.get(mi, 0), projTimeScale)
-                               : Udiag.get(mi, 0);
+        const double udiagRaw = Udiag.get(mi, 0);
+        const double udiag =
+          (extractDiag && udiagRaw == 0.0) ? projTimeScale : udiagRaw;
         const double fac = 1.0 / (rhoNp1.get(mi, 0) * udiag);
         //  undo Projection step
         velNp1.get(mi, 1) += fac * (dpdx.get(mi, 1) - uTmp.get(mi, 1));
@@ -994,9 +995,9 @@ LowMachEquationSystem::project_nodal_velocity()
       kynema_ugf_ngp::run_entity_algorithm(
         "nodal_velocity_projection_strongZ", ngpMesh, stk::topology::NODE_RANK,
         selZ, KOKKOS_LAMBDA(const MeshIndex& mi) {
-          const double udiag = extractDiag
-                                 ? Kokkos::max(Udiag.get(mi, 0), projTimeScale)
-                                 : Udiag.get(mi, 0);
+          const double udiagRaw = Udiag.get(mi, 0);
+          const double udiag =
+            (extractDiag && udiagRaw == 0.0) ? projTimeScale : udiagRaw;
           const double fac = 1.0 / (rhoNp1.get(mi, 0) * udiag);
           //  undo Projection step
           velNp1.get(mi, 2) += fac * (dpdx.get(mi, 2) - uTmp.get(mi, 2));

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -908,8 +908,8 @@ LowMachEquationSystem::project_nodal_velocity()
 
   // NOTE: re-acquire field references AFTER the PNG update
   const auto& fieldMgr = realm_.ngp_field_manager();
-  auto& uTmp = fieldMgr.get_field<double>(
-    momentumEqSys_->uTmp_->mesh_meta_data_ordinal());
+  auto& uTmp =
+    fieldMgr.get_field<double>(momentumEqSys_->uTmp_->mesh_meta_data_ordinal());
   auto& dpdx = fieldMgr.get_field<double>(
     continuityEqSys_->dpdx_->mesh_meta_data_ordinal());
   auto& Udiag = fieldMgr.get_field<double>(
@@ -934,8 +934,7 @@ LowMachEquationSystem::project_nodal_velocity()
   // zero initialisation value set before the solve.  Guard against
   // possible divide-by-zero by substituting the default timescale
   // (gamma1/dt) only for those zero-valued nodes.
-  const double projTimeScale =
-    realm_.get_gamma1() / realm_.get_time_step();
+  const double projTimeScale = realm_.get_gamma1() / realm_.get_time_step();
   const bool extractDiag =
     (realm_.solutionOptions_->tscaleType_ == TSCALE_UDIAGINV);
   {

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -906,11 +906,7 @@ LowMachEquationSystem::project_nodal_velocity()
   //==========================================================
   continuityEqSys_->compute_projected_nodal_gradient();
 
-  // NOTE: re-acquire field references AFTER the PNG update; handles obtained
-  // beforehand may be invalidated by field-data reallocation inside
-  // compute_projected_nodal_gradient() (e.g. when projected_timescale_type is
-  // momentum_diag_inv with a periodic boundary), causing a stale-pointer
-  // SIGFPE in the Kokkos lambdas below.
+  // NOTE: re-acquire field references AFTER the PNG update
   const auto& fieldMgr = realm_.ngp_field_manager();
   auto& uTmp = fieldMgr.get_field<double>(
     momentumEqSys_->uTmp_->mesh_meta_data_ordinal());
@@ -935,12 +931,9 @@ LowMachEquationSystem::project_nodal_velocity()
   //==========================================================
   // When using TSCALE_UDIAGINV, Udiag is assembled from the momentum-system
   // diagonal; slave/halo/periodic nodes excluded from that assembly retain the
-  // zero initialisation value set before the solve.  Guard against the
-  // resulting divide-by-zero by substituting the default timescale
-  // (gamma1/dt) only for those zero-valued nodes, leaving all other nodes
-  // numerically unchanged.  dt > 0 here because project_nodal_velocity() is
-  // only called from solve_and_update() after the time integrator has set a
-  // valid time step.
+  // zero initialisation value set before the solve.  Guard against
+  // possible divide-by-zero by substituting the default timescale
+  // (gamma1/dt) only for those zero-valued nodes.
   const double projTimeScale =
     realm_.get_gamma1() / realm_.get_time_step();
   const bool extractDiag =

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -886,23 +886,16 @@ LowMachEquationSystem::project_nodal_velocity()
   const int nDim = meta_data.spatial_dimension();
 
   const auto& ngpMesh = realm_.ngp_mesh();
-  const auto& fieldMgr = realm_.ngp_field_manager();
-  auto uTmp =
-    fieldMgr.get_field<double>(momentumEqSys_->uTmp_->mesh_meta_data_ordinal());
-  auto dpdx = fieldMgr.get_field<double>(
-    continuityEqSys_->dpdx_->mesh_meta_data_ordinal());
-  auto Udiag = fieldMgr.get_field<double>(
-    momentumEqSys_->get_diagonal_field()->mesh_meta_data_ordinal());
-  auto velNp1 = fieldMgr.get_field<double>(
-    momentumEqSys_->velocity_->field_of_state(stk::mesh::StateNP1)
-      .mesh_meta_data_ordinal());
-  auto rhoNp1 = fieldMgr.get_field<double>(
-    density_->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal());
 
   //==========================================================
   // save off dpdx to uTmp (do it everywhere)
   //==========================================================
   {
+    const auto& fieldMgr = realm_.ngp_field_manager();
+    auto& uTmp = fieldMgr.get_field<double>(
+      momentumEqSys_->uTmp_->mesh_meta_data_ordinal());
+    auto& dpdx = fieldMgr.get_field<double>(
+      continuityEqSys_->dpdx_->mesh_meta_data_ordinal());
     const stk::mesh::Selector sel =
       stk::mesh::selectField(*continuityEqSys_->dpdx_);
     kynema_ugf_ngp::field_copy(ngpMesh, sel, uTmp, dpdx, nDim);
@@ -912,6 +905,24 @@ LowMachEquationSystem::project_nodal_velocity()
   // safe to update pressure gradient
   //==========================================================
   continuityEqSys_->compute_projected_nodal_gradient();
+
+  // NOTE: re-acquire field references AFTER the PNG update; handles obtained
+  // beforehand may be invalidated by field-data reallocation inside
+  // compute_projected_nodal_gradient() (e.g. when projected_timescale_type is
+  // momentum_diag_inv with a periodic boundary), causing a stale-pointer
+  // SIGFPE in the Kokkos lambdas below.
+  const auto& fieldMgr = realm_.ngp_field_manager();
+  auto& uTmp = fieldMgr.get_field<double>(
+    momentumEqSys_->uTmp_->mesh_meta_data_ordinal());
+  auto& dpdx = fieldMgr.get_field<double>(
+    continuityEqSys_->dpdx_->mesh_meta_data_ordinal());
+  auto& Udiag = fieldMgr.get_field<double>(
+    momentumEqSys_->get_diagonal_field()->mesh_meta_data_ordinal());
+  auto& velNp1 = fieldMgr.get_field<double>(
+    momentumEqSys_->velocity_->field_of_state(stk::mesh::StateNP1)
+      .mesh_meta_data_ordinal());
+  auto& rhoNp1 = fieldMgr.get_field<double>(
+    density_->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal());
 
   uTmp.sync_to_device();
   dpdx.sync_to_device();


### PR DESCRIPTION
## Summary

NGP field handles in LowMachEquationSystem::project_nodal_velocity() were acquired by value (auto) before compute_projected_nodal_gradient(), which can reallocate field data (triggered by projected_timescale_type: momentum_diag_inv + periodic BCs, as in SSTWallHumpEdge). The stale copies then carry dangling stride/bucket metadata; when the Kokkos lambdas call .get() on them.

There was also a divide by 0 in the calculation of `fac`.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
