### PR TITLE
Guard SSTLR wall-distance/SDR divisors to prevent SIGFPE

### DIFF
--- a/src/ngp_algorithms/TurbViscSSTLRAlg.C
+++ b/src/ngp_algorithms/TurbViscSSTLRAlg.C
@@ -111,8 +111,7 @@ TurbViscSSTLRAlg::execute()
       const DblType tviscSST =
         aOne * density.get(meshIdx, 0) * tkeSafe /
         stk::math::max(aOne * sdr.get(meshIdx, 0), sijMag * fTwo);
-      const DblType tviscKW = aStar * density.get(meshIdx, 0) *
-                              tkeSafe /
+      const DblType tviscKW = aStar * density.get(meshIdx, 0) * tkeSafe /
                               stk::math::max(omegaHat, 1.e-8);
       tvisc.get(meshIdx, 0) = fOne * tviscKW + (1 - fOne) * tviscSST;
     });

--- a/src/ngp_algorithms/TurbViscSSTLRAlg.C
+++ b/src/ngp_algorithms/TurbViscSSTLRAlg.C
@@ -87,17 +87,17 @@ TurbViscSSTLRAlg::execute()
       // Guard against zero wall distance (e.g. at wall nodes) and zero sdr
       const DblType minDist = stk::math::max(minD.get(meshIdx, 0), 1.0e-16);
       const DblType sdrSafe = stk::math::max(sdr.get(meshIdx, 0), 1.0e-16);
+      const DblType tkeSafe = stk::math::max(tke.get(meshIdx, 0), 0.0);
       const DblType minDSq = minDist * minDist;
       const DblType trbDiss =
-        stk::math::sqrt(stk::math::max(tke.get(meshIdx, 0), 0.0)) / betaStar /
-        sdrSafe / minDist;
+        stk::math::sqrt(tkeSafe) / betaStar / sdrSafe / minDist;
       const DblType lamDiss = 500.0 * visc.get(meshIdx, 0) /
                               density.get(meshIdx, 0) / sdrSafe / minDSq;
       const DblType fArgTwo = stk::math::max(2.0 * trbDiss, lamDiss);
       const DblType fTwo = stk::math::tanh(fArgTwo * fArgTwo);
 
-      const DblType ReTurb = density.get(meshIdx, 0) * tke.get(meshIdx, 0) /
-                             sdrSafe / visc.get(meshIdx, 0);
+      const DblType ReTurb =
+        density.get(meshIdx, 0) * tkeSafe / sdrSafe / visc.get(meshIdx, 0);
 
       const DblType rK = 6.0;
       const DblType a0Star = 0.072 / 3.0;
@@ -109,10 +109,10 @@ TurbViscSSTLRAlg::execute()
 
       const DblType fOne = fOneBlend.get(meshIdx, 0);
       const DblType tviscSST =
-        aOne * density.get(meshIdx, 0) * tke.get(meshIdx, 0) /
+        aOne * density.get(meshIdx, 0) * tkeSafe /
         stk::math::max(aOne * sdr.get(meshIdx, 0), sijMag * fTwo);
       const DblType tviscKW = aStar * density.get(meshIdx, 0) *
-                              tke.get(meshIdx, 0) /
+                              tkeSafe /
                               stk::math::max(omegaHat, 1.e-8);
       tvisc.get(meshIdx, 0) = fOne * tviscKW + (1 - fOne) * tviscSST;
     });

--- a/src/ngp_algorithms/TurbViscSSTLRAlg.C
+++ b/src/ngp_algorithms/TurbViscSSTLRAlg.C
@@ -84,17 +84,20 @@ TurbViscSSTLRAlg::execute()
       }
       sijMag = stk::math::sqrt(2.0 * sijMag);
 
-      const DblType minDSq = minD.get(meshIdx, 0) * minD.get(meshIdx, 0);
-      const DblType trbDiss = stk::math::sqrt(tke.get(meshIdx, 0)) / betaStar /
-                              sdr.get(meshIdx, 0) / minD.get(meshIdx, 0);
+      // Guard against zero wall distance (e.g. at wall nodes) and zero sdr
+      const DblType minDist = stk::math::max(minD.get(meshIdx, 0), 1.0e-16);
+      const DblType sdrSafe = stk::math::max(sdr.get(meshIdx, 0), 1.0e-16);
+      const DblType minDSq = minDist * minDist;
+      const DblType trbDiss =
+        stk::math::sqrt(stk::math::max(tke.get(meshIdx, 0), 0.0)) / betaStar /
+        sdrSafe / minDist;
       const DblType lamDiss = 500.0 * visc.get(meshIdx, 0) /
-                              density.get(meshIdx, 0) / sdr.get(meshIdx, 0) /
-                              minDSq;
+                              density.get(meshIdx, 0) / sdrSafe / minDSq;
       const DblType fArgTwo = stk::math::max(2.0 * trbDiss, lamDiss);
       const DblType fTwo = stk::math::tanh(fArgTwo * fArgTwo);
 
       const DblType ReTurb = density.get(meshIdx, 0) * tke.get(meshIdx, 0) /
-                             sdr.get(meshIdx, 0) / visc.get(meshIdx, 0);
+                             sdrSafe / visc.get(meshIdx, 0);
 
       const DblType rK = 6.0;
       const DblType a0Star = 0.072 / 3.0;


### PR DESCRIPTION
## Summary

Prevent TurbViscSSTLRAlg::execute() from triggering AddressSanitizer FPE/NaN in SSTLRChannelEdge by hardening zero/near-zero divisor paths (minimum_distance_to_wall, specific_dissipation_rate) and clamping negative tke input before sqrt.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
