### PR TITLE
Reduce time steps for some long running tests

### DIFF
--- a/reg_tests/test_files/VOFDroplet/VOFDroplet.yaml
+++ b/reg_tests/test_files/VOFDroplet/VOFDroplet.yaml
@@ -143,7 +143,7 @@ Time_Integrators:
   - StandardTimeIntegrator:
       name: ti_1
       start_time: 0
-      termination_time: 0.0003
+      termination_time: 0.0002
       time_step: 0.0001
       time_stepping_type: fixed
       time_step_count: 5

--- a/reg_tests/test_files/VOFDroplet/VOFDroplet.yaml
+++ b/reg_tests/test_files/VOFDroplet/VOFDroplet.yaml
@@ -146,7 +146,7 @@ Time_Integrators:
       termination_time: 0.0003
       time_step: 0.0001
       time_stepping_type: fixed
-      time_step_count: 10
+      time_step_count: 5
       second_order_accuracy: yes
 
 

--- a/reg_tests/test_files/VOFInertialDroplet/VOFInertialDroplet.yaml
+++ b/reg_tests/test_files/VOFInertialDroplet/VOFInertialDroplet.yaml
@@ -128,7 +128,7 @@ Time_Integrators:
       termination_time: 0.015
       time_step: 0.005
       time_stepping_type: fixed
-      time_step_count: 10
+      time_step_count: 5
       second_order_accuracy: yes
 
 

--- a/reg_tests/test_files/VOFInertialDroplet/VOFInertialDroplet.yaml
+++ b/reg_tests/test_files/VOFInertialDroplet/VOFInertialDroplet.yaml
@@ -125,7 +125,7 @@ Time_Integrators:
   - StandardTimeIntegrator:
       name: ti_1
       start_time: 0
-      termination_time: 0.015
+      termination_time: 0.0075
       time_step: 0.005
       time_stepping_type: fixed
       time_step_count: 5

--- a/reg_tests/test_files/edgeHybridFluids/edgeHybridFluids.yaml
+++ b/reg_tests/test_files/edgeHybridFluids/edgeHybridFluids.yaml
@@ -119,7 +119,7 @@ Time_Integrators:
   - StandardTimeIntegrator:
       name: ti_1
       start_time: 0
-      termination_time: 0.1
+      termination_time: 0.05
       time_step: 0.01
       time_stepping_type: adaptive 
       time_step_count: 0


### PR DESCRIPTION
## Summary

Some of the longest running tests don't use a fixed number of timesteps. This reduces the number of timesteps for these tests.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
