### PR TITLE
Add Beam mapping methods to KynemaFMBBase

### DIFF
--- a/include/aero/fmb/KynemaFMBBase.h
+++ b/include/aero/fmb/KynemaFMBBase.h
@@ -6,6 +6,7 @@
 #include <stk_mesh/base/Part.hpp>
 #include "FieldTypeDef.h"
 #include "aero/fsi/CalcLoads.h"
+#include "aero/fsi/CalcLoadsAssembled.h"
 
 namespace sierra {
 namespace kynema_ugf {
@@ -30,6 +31,66 @@ struct PointMass
   PointData p_data;
 };
 
+template <typename Space>
+struct BeamDataT
+{
+  using scalar_view_type = Kokkos::View<double*, Space>;
+  using pos_view_type = Kokkos::View<double* [7], Space>;
+  using vel_view_type = Kokkos::View<double* [6], Space>;
+  using load_view_type = Kokkos::View<double* [6], Space>;
+
+  scalar_view_type bary_weights; // Barycentric weights for interpolation nodes
+  scalar_view_type node_xi; // Non-dimensional location of each node along the beam
+  pos_view_type pos;       // First 3 are position, last 4 are quaternion orientation
+  pos_view_type disp;      // First 3 are translational displacement, last 4 are quaternion rotations
+  vel_view_type vel;       // First 3 are translational velocity, last 3 are rotational velocity
+  load_view_type loads;     // First 3 are forces, last 3 are moments
+
+  BeamDataT() = default;
+
+  explicit BeamDataT(const std::size_t nNodes, const std::string& labelPrefix = "beam")
+  {
+    resize(nNodes, labelPrefix);
+  }
+
+  void resize(const std::size_t nNodes, const std::string& labelPrefix = "beam")
+  {
+    bary_weights = scalar_view_type(labelPrefix + "_bary_weights", nNodes);
+    node_xi = scalar_view_type(labelPrefix + "_node_xi", nNodes);
+    pos = pos_view_type(labelPrefix + "_pos", nNodes);
+    disp = pos_view_type(labelPrefix + "_disp", nNodes);
+    vel = vel_view_type(labelPrefix + "_vel", nNodes);
+    loads = load_view_type(labelPrefix + "_loads", nNodes);
+  }
+
+  std::size_t size() const { return node_xi.extent(0); }
+
+};
+
+using BeamDataDevice = BeamDataT<MemSpace>;
+using BeamDataHost = BeamDataT<HostSpace>;
+using BeamData = BeamDataDevice;
+
+struct BeamBody
+{
+
+  size_t n_nodes = 0;
+
+  BeamData beam_data;
+  BeamDataHost beam_data_host;
+
+  std::vector<std::string> forcing_surface_names;
+  std::vector<std::string> moving_mesh_block_names;
+  stk::mesh::PartVector forcing_surfaces;
+  stk::mesh::PartVector moving_mesh_blocks;
+
+  GenericFieldType* total_force = nullptr;
+  std::shared_ptr<stk::mesh::BulkData> bulk = nullptr;
+  std::shared_ptr<CalcLoadsAssembled> calc_loads = nullptr;
+
+};
+
+
 class KynemaFMBBase
 {
 public:
@@ -42,12 +103,18 @@ public:
 
   virtual void map_displacements(double currentTime, bool updateCurCoor) = 0;
 
+  void compute_mapping_beam(BeamBody& beam);
+
+  void map_displacements_beam(BeamBody& beam, bool updateCur);
+
   void map_displacements_point(PointMass& point, bool updateCur);
 
   virtual void
   advance_struct_timestep(const double currentTime, const double dT) = 0;
 
   virtual void map_loads(const double currentTime) = 0;
+
+  void map_loads_beam(BeamBody& beam);
 
   void map_loads_point(PointMass& point);
 

--- a/include/aero/fmb/KynemaFMBBase.h
+++ b/include/aero/fmb/KynemaFMBBase.h
@@ -40,15 +40,19 @@ struct BeamDataT
   using load_view_type = Kokkos::View<double* [6], Space>;
 
   scalar_view_type bary_weights; // Barycentric weights for interpolation nodes
-  scalar_view_type node_xi; // Non-dimensional location of each node along the beam
-  pos_view_type pos;       // First 3 are position, last 4 are quaternion orientation
-  pos_view_type disp;      // First 3 are translational displacement, last 4 are quaternion rotations
-  vel_view_type vel;       // First 3 are translational velocity, last 3 are rotational velocity
-  load_view_type loads;     // First 3 are forces, last 3 are moments
+  scalar_view_type
+    node_xi;          // Non-dimensional location of each node along the beam
+  pos_view_type pos;  // First 3 are position, last 4 are quaternion orientation
+  pos_view_type disp; // First 3 are translational displacement, last 4 are
+                      // quaternion rotations
+  vel_view_type
+    vel; // First 3 are translational velocity, last 3 are rotational velocity
+  load_view_type loads; // First 3 are forces, last 3 are moments
 
   BeamDataT() = default;
 
-  explicit BeamDataT(const std::size_t nNodes, const std::string& labelPrefix = "beam")
+  explicit BeamDataT(
+    const std::size_t nNodes, const std::string& labelPrefix = "beam")
   {
     resize(nNodes, labelPrefix);
   }
@@ -64,7 +68,6 @@ struct BeamDataT
   }
 
   std::size_t size() const { return node_xi.extent(0); }
-
 };
 
 using BeamDataDevice = BeamDataT<MemSpace>;
@@ -87,9 +90,7 @@ struct BeamBody
   GenericFieldType* total_force = nullptr;
   std::shared_ptr<stk::mesh::BulkData> bulk = nullptr;
   std::shared_ptr<CalcLoadsAssembled> calc_loads = nullptr;
-
 };
-
 
 class KynemaFMBBase
 {

--- a/include/aero/fmb/KynemaFMBBeamUtils.h
+++ b/include/aero/fmb/KynemaFMBBeamUtils.h
@@ -1,3 +1,5 @@
+ #include <Kokkos_Core.hpp>
+
 namespace sierra {
 namespace kynema_ugf {
 
@@ -464,6 +466,11 @@ FindClosestPointOnBlade(
       const double fprime_new = BladePointFPrimeAtXi(
         xi_new, query_point, node_xi, node_positions, num_nodes, bary_weights,
         scratch_weights, scratch_dweights);
+      if (std::abs(fprime_new) < 1.e-14) {
+        a = xi_new;
+        b = xi_new;
+        break;
+      }
       // Narrow the bracket.
       if (fprime_new * fprime_a < 0.0) {
         b = xi_new;

--- a/include/aero/fmb/KynemaFMBBeamUtils.h
+++ b/include/aero/fmb/KynemaFMBBeamUtils.h
@@ -1,0 +1,485 @@
+namespace sierra {
+namespace kynema_ugf {
+
+
+
+    
+/**
+ * @brief Rotates provided vector by provided *unit* quaternion and returns the result
+ */
+template <typename Quaternion, typename View1, typename View2>
+KOKKOS_INLINE_FUNCTION void RotateVectorByQuaternion(
+    const Quaternion& q, const View1& v, View2& v_rot
+) {
+    v_rot[0] = (q[0] * q[0] + q[1] * q[1] - q[2] * q[2] - q[3] * q[3]) * v[0] +
+               2. * (q[1] * q[2] - q[0] * q[3]) * v[1] + 2. * (q[1] * q[3] + q[0] * q[2])
+ * v[2];
+    v_rot[1] = 2. * (q[1] * q[2] + q[0] * q[3]) * v[0] +
+               (q[0] * q[0] - q[1] * q[1] + q[2] * q[2] - q[3] * q[3]) * v[1] +
+               2. * (q[2] * q[3] - q[0] * q[1]) * v[2];
+    v_rot[2] = 2. * (q[1] * q[3] - q[0] * q[2]) * v[0] + 2. * (q[2] * q[3] + q[0] * q[1])
+ * v[1] +
+               (q[0] * q[0] - q[1] * q[1] - q[2] * q[2] + q[3] * q[3]) * v[2];
+}
+
+/**
+ * @brief Rotates provided vector by inverse of provided *unit* quaternion and returns the result
+ */
+template <typename Quaternion, typename View1, typename View2>
+KOKKOS_INLINE_FUNCTION void RotateVectorByQuaternionInv(
+    const Quaternion& q, const View1& v, View2& v_rot
+) {
+    v_rot[0] = (q[0] * q[0] + q[1] * q[1] - q[2] * q[2] - q[3] * q[3]) * v[0] +
+               2. * (q[1] * q[2] + q[0] * q[3]) * v[1] + 2. * (q[1] * q[3] - q[0] * q[2])
+ * v[2];
+    v_rot[1] = 2. * (q[1] * q[2] - q[0] * q[3]) * v[0] +
+               (q[0] * q[0] - q[1] * q[1] + q[2] * q[2] - q[3] * q[3]) * v[1] +
+               2. * (q[2] * q[3] + q[0] * q[1]) * v[2];
+    v_rot[2] = 2. * (q[1] * q[3] + q[0] * q[2]) * v[0] + 2. * (q[2] * q[3] - q[0] * q[1])
+ * v[1] +
+               (q[0] * q[0] - q[1] * q[1] - q[2] * q[2] + q[3] * q[3]) * v[2];
+}
+
+/**
+ * @brief Computes 3D cross product of two vectors and stores the result.
+ */
+template <typename View1, typename View2, typename View3>
+KOKKOS_INLINE_FUNCTION void CrossProduct3(
+    const View1& a, const View2& b, View3& c
+) {
+    c[0] = a[1] * b[2] - a[2] * b[1];
+    c[1] = a[2] * b[0] - a[0] * b[2];
+    c[2] = a[0] * b[1] - a[1] * b[0];
+}
+
+/**
+ * @brief Computes barycentric weights for interpolation nodes.
+ *
+ * Compute once for a given node set and reuse for many evaluations.
+ * This is O(n^2) and intended for setup, not the hot loop.
+ *
+ * @param xs Interpolation nodes
+ * @param n Number of interpolation nodes
+ * @param bary_weights Output barycentric weights (size n)
+ */
+KOKKOS_INLINE_FUNCTION
+inline void ComputeBarycentricWeights(
+    const double* KOKKOS_RESTRICT xs, int n, double* KOKKOS_RESTRICT bary_weights
+) {
+    for (int j = 0; j < n; ++j) {
+        double w = 1.0;
+        for (int m = 0; m < n; ++m) {
+            if (j != m) {
+                w /= (xs[j] - xs[m]);
+            }
+        }
+        bary_weights[j] = w;
+    }
+}
+
+/**
+ * @brief Computes Lagrange interpolation basis weights at x.
+ *
+ * Barycentric form is O(n) per evaluation and avoids dynamic allocations,
+ * making it suitable for use inside Kokkos kernels.
+ *
+ * @param x Evaluation point
+ * @param xs Interpolation nodes
+ * @param bary_weights Precomputed barycentric node weights
+ * @param n Number of interpolation nodes
+ * @param weights Output interpolation basis weights (size n)
+ */
+KOKKOS_INLINE_FUNCTION
+inline void LagrangePolynomialInterpWeights(
+    double x,
+    const double* KOKKOS_RESTRICT xs,
+    const double* KOKKOS_RESTRICT bary_weights,
+    int n,
+    double* KOKKOS_RESTRICT weights
+) {
+    constexpr double tol = 1.e-14;
+
+    // If x coincides with a node, return exact Kronecker-delta basis values.
+    for (int j = 0; j < n; ++j) {
+        if (std::abs(x - xs[j]) <= tol) {
+            for (int k = 0; k < n; ++k) {
+                weights[k] = 0.0;
+            }
+            weights[j] = 1.0;
+            return;
+        }
+    }
+
+    double denom = 0.0;
+    for (int j = 0; j < n; ++j) {
+        const double tmp = bary_weights[j] / (x - xs[j]);
+        weights[j] = tmp;
+        denom += tmp;
+    }
+
+    const double inv_denom = 1.0 / denom;
+    for (int j = 0; j < n; ++j) {
+        weights[j] *= inv_denom;
+    }
+}
+
+/**
+ * @brief Computes Lagrange basis values and their xi-derivatives in one pass.
+ *
+ * At interior points uses the barycentric derivative formula:
+ *   dl_j/dx = l_j * (S2/S - 1/(x - x_j))
+ * where S = sum_k w_k/(x-x_k) and S2 = sum_k w_k/(x-x_k)^2.
+ * At exact nodes uses the standard nodal derivative formula.
+ *
+ * @param x Evaluation point
+ * @param xs Interpolation nodes
+ * @param bary_weights Precomputed barycentric node weights
+ * @param n Number of interpolation nodes
+ * @param weights Output basis values l_j(x) (size n)
+ * @param dweights Output basis derivatives dl_j/dx (size n)
+ */
+KOKKOS_INLINE_FUNCTION
+inline void LagrangePolynomialInterpWeightsAndDerivatives(
+    double x,
+    const double* KOKKOS_RESTRICT xs,
+    const double* KOKKOS_RESTRICT bary_weights,
+    int n,
+    double* KOKKOS_RESTRICT weights,
+    double* KOKKOS_RESTRICT dweights
+) {
+    constexpr double tol = 1.e-14;
+
+    // Exact-node case: l_m=1, l_j=0 for j!=m; use standard nodal derivative formula.
+    for (int j = 0; j < n; ++j) {
+        if (std::abs(x - xs[j]) <= tol) {
+            for (int k = 0; k < n; ++k) {
+                weights[k]  = 0.0;
+                dweights[k] = 0.0;
+            }
+            weights[j] = 1.0;
+            double sum_d = 0.0;
+            for (int k = 0; k < n; ++k) {
+                if (k != j) {
+                    dweights[k] = (bary_weights[k] / bary_weights[j]) / (xs[j] - xs[k]);
+                    sum_d += dweights[k];
+                }
+            }
+            dweights[j] = -sum_d;
+            return;
+        }
+    }
+
+    // General case: single-pass over nodes accumulates S and S2.
+    // S  = sum_k w_k/(x-x_k)   (barycentric denominator)
+    // S2 = sum_k w_k/(x-x_k)^2 (needed for derivative)
+    double S  = 0.0;
+    double S2 = 0.0;
+    for (int j = 0; j < n; ++j) {
+        const double diff = x - xs[j];
+        const double t    = bary_weights[j] / diff;
+        weights[j] = t;  // temporarily store t_j = w_j/(x-x_j)
+        S  += t;
+        S2 += t / diff;
+    }
+
+    const double inv_S = 1.0 / S;
+    const double ratio = S2 * inv_S;  // S2/S, scalar shared across all j
+    for (int j = 0; j < n; ++j) {
+        const double lj = weights[j] * inv_S;
+        weights[j]  = lj;
+        dweights[j] = lj * (ratio - 1.0 / (x - xs[j]));
+    }
+}
+
+/**
+ * @brief Computes shape function matrix ϕg relating points ξb to ξg.
+ *
+ * Layout of shape_functions is row-major with [output][input], flattened as
+ * shape_functions[output_idx * num_input_points + input_idx].
+ *
+ * @param input_points Input points ξb in [-1, 1]
+ * @param num_input_points Number of input points
+ * @param output_points Output points ξg in [-1, 1]
+ * @param output_bary_weights Precomputed barycentric weights for output_points
+ * @param num_output_points Number of output points
+ * @param scratch_weights Scratch array of size num_output_points
+ * @param shape_functions Output flattened shape matrix [num_output_points * num_input_points]
+ */
+KOKKOS_INLINE_FUNCTION
+inline void ComputeShapeFunctionValues(
+    const double* KOKKOS_RESTRICT input_points,
+    int num_input_points,
+    const double* KOKKOS_RESTRICT output_points,
+    const double* KOKKOS_RESTRICT output_bary_weights,
+    int num_output_points,
+    double* KOKKOS_RESTRICT scratch_weights,
+    double* KOKKOS_RESTRICT shape_functions
+) {
+    for (int input_point = 0; input_point < num_input_points; ++input_point) {
+        LagrangePolynomialInterpWeights(
+            input_points[input_point],
+            output_points,
+            output_bary_weights,
+            num_output_points,
+            scratch_weights
+        );
+
+        for (int output_point = 0; output_point < num_output_points; ++output_point) {
+            shape_functions[output_point * num_input_points + input_point] =
+                scratch_weights[output_point];
+        }
+    }
+}
+
+/**
+ * @brief Interpolates a field at an evaluation point using Lagrange basis functions.
+ *
+ * Computes the interpolated value of a field at a given parametric coordinate
+ * using precomputed barycentric weights and Lagrange basis functions.
+ *
+ * @param x_eval Evaluation point in parameter space
+ * @param node_xi Node parametric coordinates (size num_nodes)
+ * @param node_field Node field values, layout [num_nodes][field_stride]
+ * @param num_nodes Number of nodes
+ * @param field_stride Number of components per node (e.g., 7 for position, 3 for displacement)
+ * @param bary_weights Precomputed barycentric weights for node_xi (size num_nodes)
+ * @param scratch_weights Scratch array for basis functions (size num_nodes)
+ * @param interp_field Output interpolated field (size field_stride)
+ */
+KOKKOS_INLINE_FUNCTION
+inline void InterpolateFieldAtPoint(
+    double x_eval,
+    const double* KOKKOS_RESTRICT node_xi,
+    const double* KOKKOS_RESTRICT node_field,
+    int num_nodes,
+    int field_stride,
+    const double* KOKKOS_RESTRICT bary_weights,
+    double* KOKKOS_RESTRICT scratch_weights,
+    double* KOKKOS_RESTRICT interp_field
+) {
+    // Compute Lagrange basis weights at x_eval
+    LagrangePolynomialInterpWeights(x_eval, node_xi, bary_weights, num_nodes, scratch_weights);
+
+    // Initialize output to zero
+    for (int c = 0; c < field_stride; ++c) {
+        interp_field[c] = 0.0;
+    }
+
+    // Interpolate each component of the field
+    for (int j = 0; j < num_nodes; ++j) {
+        const double basis_j = scratch_weights[j];
+        for (int c = 0; c < field_stride; ++c) {
+            interp_field[c] += basis_j * node_field[j * field_stride + c];
+        }
+    }
+}
+
+KOKKOS_INLINE_FUNCTION
+inline double SquaredDistance3(
+    const double* KOKKOS_RESTRICT a, const double* KOKKOS_RESTRICT b
+) {
+    const double dx = a[0] - b[0];
+    const double dy = a[1] - b[1];
+    const double dz = a[2] - b[2];
+    return dx * dx + dy * dy + dz * dz;
+}
+
+KOKKOS_INLINE_FUNCTION
+inline double BladePointDistanceSquaredAtXi(
+    double xi,
+    const double* KOKKOS_RESTRICT query_point,
+    const double* KOKKOS_RESTRICT node_xi,
+    const double* KOKKOS_RESTRICT node_positions,
+    int num_nodes,
+    const double* KOKKOS_RESTRICT bary_weights,
+    double* KOKKOS_RESTRICT scratch_weights,
+    double* KOKKOS_RESTRICT interp_position
+) {
+    // Interpolate only xyz from node_positions[num_nodes][7] to reduce work in the hot path.
+    LagrangePolynomialInterpWeights(xi, node_xi, bary_weights, num_nodes, scratch_weights);
+
+    interp_position[0] = 0.0;
+    interp_position[1] = 0.0;
+    interp_position[2] = 0.0;
+    for (int j = 0; j < num_nodes; ++j) {
+        const double basis_j = scratch_weights[j];
+        interp_position[0] += basis_j * node_positions[j * 7 + 0];
+        interp_position[1] += basis_j * node_positions[j * 7 + 1];
+        interp_position[2] += basis_j * node_positions[j * 7 + 2];
+    }
+
+    return SquaredDistance3(interp_position, query_point);
+}
+
+/**
+ * @brief Evaluates f'(xi) = 2*(r(xi)-q) . r'(xi) in one pass.
+ *
+ * r(xi) and r'(xi) are the interpolated blade position and its xi-derivative.
+ * f'(xi) = 0 is the necessary condition for a closest-point projection.
+ *
+ * @param xi Parametric evaluation point
+ * @param query_point Target point [x, y, z]
+ * @param node_xi Blade nodal xi coordinates
+ * @param node_positions Blade nodal positions, flattened [num_nodes][7]
+ * @param num_nodes Number of blade nodes
+ * @param bary_weights Precomputed barycentric weights for node_xi
+ * @param scratch_weights Scratch array size num_nodes (basis values)
+ * @param scratch_dweights Scratch array size num_nodes (basis derivatives)
+ */
+KOKKOS_INLINE_FUNCTION
+inline double BladePointFPrimeAtXi(
+    double xi,
+    const double* KOKKOS_RESTRICT query_point,
+    const double* KOKKOS_RESTRICT node_xi,
+    const double* KOKKOS_RESTRICT node_positions,
+    int num_nodes,
+    const double* KOKKOS_RESTRICT bary_weights,
+    double* KOKKOS_RESTRICT scratch_weights,
+    double* KOKKOS_RESTRICT scratch_dweights
+) {
+    LagrangePolynomialInterpWeightsAndDerivatives(
+        xi, node_xi, bary_weights, num_nodes, scratch_weights, scratch_dweights
+    );
+
+    double r[3]      = {0.0, 0.0, 0.0};
+    double rprime[3] = {0.0, 0.0, 0.0};
+    for (int j = 0; j < num_nodes; ++j) {
+        const double lj  = scratch_weights[j];
+        const double dlj = scratch_dweights[j];
+        r[0]      += lj  * node_positions[j * 7 + 0];
+        r[1]      += lj  * node_positions[j * 7 + 1];
+        r[2]      += lj  * node_positions[j * 7 + 2];
+        rprime[0] += dlj * node_positions[j * 7 + 0];
+        rprime[1] += dlj * node_positions[j * 7 + 1];
+        rprime[2] += dlj * node_positions[j * 7 + 2];
+    }
+
+    return 2.0 * (
+        (r[0] - query_point[0]) * rprime[0] +
+        (r[1] - query_point[1]) * rprime[1] +
+        (r[2] - query_point[2]) * rprime[2]
+    );
+}
+
+/**
+ * @brief Finds closest point on blade centerline to a query point.
+ *
+ * Minimizes squared distance over xi in [-1, 1] with:
+ * 1) coarse uniform scan to bracket the minimum
+ * 2) bracketed secant method on f'(xi)=0 for fast refinement
+ *
+ * @param query_point Target point [x, y, z]
+ * @param node_xi Blade nodal xi coordinates
+ * @param node_positions Blade nodal positions, flattened [num_nodes][7]
+ * @param num_nodes Number of blade nodes
+ * @param bary_weights Barycentric weights for node_xi
+ * @param scratch_weights Scratch array size num_nodes (basis values)
+ * @param scratch_dweights Scratch array size num_nodes (basis derivatives)
+ * @param out_xi Closest xi in [-1, 1]
+ * @param out_position Closest interpolated position [x, y, z]
+ * @param out_dist2 Minimum squared distance
+ */
+KOKKOS_INLINE_FUNCTION
+inline void FindClosestPointOnBlade(
+    const double* KOKKOS_RESTRICT query_point,
+    const double* KOKKOS_RESTRICT node_xi,
+    const double* KOKKOS_RESTRICT node_positions,
+    int num_nodes,
+    const double* KOKKOS_RESTRICT bary_weights,
+    double* KOKKOS_RESTRICT scratch_weights,
+    double* KOKKOS_RESTRICT scratch_dweights,
+    double& out_xi,
+    double* KOKKOS_RESTRICT out_position,
+    double& out_dist2
+) {
+    constexpr int    kCoarseSamples = 10;
+    constexpr int    kSecantIters   = 8;
+    constexpr double kXiMin         = -1.0;
+    constexpr double kXiMax         =  1.0;
+
+    double interp_tmp[3];
+
+    // Stage 1: coarse uniform scan to locate the bracket containing the minimum.
+    int    best_index = 0;
+    double best_xi    = kXiMin;
+    double best_dist2 = BladePointDistanceSquaredAtXi(
+        best_xi, query_point, node_xi, node_positions, num_nodes, bary_weights,
+        scratch_weights, interp_tmp
+    );
+
+    for (int i = 1; i < kCoarseSamples; ++i) {
+        const double t  = static_cast<double>(i) / static_cast<double>(kCoarseSamples - 1);
+        const double xi = kXiMin + (kXiMax - kXiMin) * t;
+        const double d2 = BladePointDistanceSquaredAtXi(
+            xi, query_point, node_xi, node_positions, num_nodes, bary_weights,
+            scratch_weights, interp_tmp
+        );
+        if (d2 < best_dist2) {
+            best_dist2 = d2;
+            best_xi    = xi;
+            best_index = i;
+        }
+    }
+
+    const int left_index  = (best_index > 0)                   ? (best_index - 1) : 0;
+    const int right_index = (best_index < kCoarseSamples - 1)  ? (best_index + 1) : (kCoarseSamples - 1);
+
+    double a = kXiMin + (kXiMax - kXiMin) * static_cast<double>(left_index)  / static_cast<double>(kCoarseSamples - 1);
+    double b = kXiMin + (kXiMax - kXiMin) * static_cast<double>(right_index) / static_cast<double>(kCoarseSamples - 1);
+
+    // Stage 2: bracketed secant on f'(xi) = 2*(r(xi)-q).r'(xi) = 0.
+    // The bracket [a, b] straddles the minimum so f'(a) <= 0 <= f'(b).
+    double fprime_a = BladePointFPrimeAtXi(
+        a, query_point, node_xi, node_positions, num_nodes, bary_weights,
+        scratch_weights, scratch_dweights
+    );
+    double fprime_b = BladePointFPrimeAtXi(
+        b, query_point, node_xi, node_positions, num_nodes, bary_weights,
+        scratch_weights, scratch_dweights
+    );
+
+    if (fprime_a * fprime_b >= 0.0) {
+        // Bracket has no sign change: minimum is at or very near a boundary.
+        // Fall back to the coarse-scan best.
+        out_xi = best_xi;
+    } else {
+        for (int iter = 0; iter < kSecantIters; ++iter) {
+            // Secant step: linear interpolation of f' to find its zero.
+            const double denom   = fprime_b - fprime_a;
+            const double xi_sec  = (std::abs(denom) > 1.e-30)
+                                   ? (a * fprime_b - b * fprime_a) / denom
+                                   : 0.5 * (a + b);
+            // Clamp to bracket as a safeguard.
+            const double xi_new  = Kokkos::min(b, Kokkos::max(a, xi_sec));
+            const double fprime_new = BladePointFPrimeAtXi(
+                xi_new, query_point, node_xi, node_positions, num_nodes, bary_weights,
+                scratch_weights, scratch_dweights
+            );
+            // Narrow the bracket.
+            if (fprime_new * fprime_a < 0.0) {
+                b        = xi_new;
+                fprime_b = fprime_new;
+            } else {
+                a        = xi_new;
+                fprime_a = fprime_new;
+            }
+            if (b - a < 1.e-12) break;
+        }
+        out_xi = 0.5 * (a + b);
+    }
+
+    // Clamp to valid domain.
+    out_xi = Kokkos::min(kXiMax, Kokkos::max(kXiMin, out_xi));
+
+    // Final position and distance at the converged xi.
+    out_dist2 = BladePointDistanceSquaredAtXi(
+        out_xi, query_point, node_xi, node_positions, num_nodes, bary_weights,
+        scratch_weights, interp_tmp
+    );
+    out_position[0] = interp_tmp[0];
+    out_position[1] = interp_tmp[1];
+    out_position[2] = interp_tmp[2];
+}
+
+} // namespace kynema_ugf
+} // namespace sierra

--- a/include/aero/fmb/KynemaFMBBeamUtils.h
+++ b/include/aero/fmb/KynemaFMBBeamUtils.h
@@ -1,4 +1,4 @@
- #include <Kokkos_Core.hpp>
+#include <Kokkos_Core.hpp>
 
 namespace sierra {
 namespace kynema_ugf {

--- a/include/aero/fmb/KynemaFMBBeamUtils.h
+++ b/include/aero/fmb/KynemaFMBBeamUtils.h
@@ -1,55 +1,54 @@
 namespace sierra {
 namespace kynema_ugf {
 
-
-
-    
 /**
- * @brief Rotates provided vector by provided *unit* quaternion and returns the result
+ * @brief Rotates provided vector by provided *unit* quaternion and returns the
+ * result
  */
 template <typename Quaternion, typename View1, typename View2>
-KOKKOS_INLINE_FUNCTION void RotateVectorByQuaternion(
-    const Quaternion& q, const View1& v, View2& v_rot
-) {
-    v_rot[0] = (q[0] * q[0] + q[1] * q[1] - q[2] * q[2] - q[3] * q[3]) * v[0] +
-               2. * (q[1] * q[2] - q[0] * q[3]) * v[1] + 2. * (q[1] * q[3] + q[0] * q[2])
- * v[2];
-    v_rot[1] = 2. * (q[1] * q[2] + q[0] * q[3]) * v[0] +
-               (q[0] * q[0] - q[1] * q[1] + q[2] * q[2] - q[3] * q[3]) * v[1] +
-               2. * (q[2] * q[3] - q[0] * q[1]) * v[2];
-    v_rot[2] = 2. * (q[1] * q[3] - q[0] * q[2]) * v[0] + 2. * (q[2] * q[3] + q[0] * q[1])
- * v[1] +
-               (q[0] * q[0] - q[1] * q[1] - q[2] * q[2] + q[3] * q[3]) * v[2];
+KOKKOS_INLINE_FUNCTION void
+RotateVectorByQuaternion(const Quaternion& q, const View1& v, View2& v_rot)
+{
+  v_rot[0] = (q[0] * q[0] + q[1] * q[1] - q[2] * q[2] - q[3] * q[3]) * v[0] +
+             2. * (q[1] * q[2] - q[0] * q[3]) * v[1] +
+             2. * (q[1] * q[3] + q[0] * q[2]) * v[2];
+  v_rot[1] = 2. * (q[1] * q[2] + q[0] * q[3]) * v[0] +
+             (q[0] * q[0] - q[1] * q[1] + q[2] * q[2] - q[3] * q[3]) * v[1] +
+             2. * (q[2] * q[3] - q[0] * q[1]) * v[2];
+  v_rot[2] = 2. * (q[1] * q[3] - q[0] * q[2]) * v[0] +
+             2. * (q[2] * q[3] + q[0] * q[1]) * v[1] +
+             (q[0] * q[0] - q[1] * q[1] - q[2] * q[2] + q[3] * q[3]) * v[2];
 }
 
 /**
- * @brief Rotates provided vector by inverse of provided *unit* quaternion and returns the result
+ * @brief Rotates provided vector by inverse of provided *unit* quaternion and
+ * returns the result
  */
 template <typename Quaternion, typename View1, typename View2>
-KOKKOS_INLINE_FUNCTION void RotateVectorByQuaternionInv(
-    const Quaternion& q, const View1& v, View2& v_rot
-) {
-    v_rot[0] = (q[0] * q[0] + q[1] * q[1] - q[2] * q[2] - q[3] * q[3]) * v[0] +
-               2. * (q[1] * q[2] + q[0] * q[3]) * v[1] + 2. * (q[1] * q[3] - q[0] * q[2])
- * v[2];
-    v_rot[1] = 2. * (q[1] * q[2] - q[0] * q[3]) * v[0] +
-               (q[0] * q[0] - q[1] * q[1] + q[2] * q[2] - q[3] * q[3]) * v[1] +
-               2. * (q[2] * q[3] + q[0] * q[1]) * v[2];
-    v_rot[2] = 2. * (q[1] * q[3] + q[0] * q[2]) * v[0] + 2. * (q[2] * q[3] - q[0] * q[1])
- * v[1] +
-               (q[0] * q[0] - q[1] * q[1] - q[2] * q[2] + q[3] * q[3]) * v[2];
+KOKKOS_INLINE_FUNCTION void
+RotateVectorByQuaternionInv(const Quaternion& q, const View1& v, View2& v_rot)
+{
+  v_rot[0] = (q[0] * q[0] + q[1] * q[1] - q[2] * q[2] - q[3] * q[3]) * v[0] +
+             2. * (q[1] * q[2] + q[0] * q[3]) * v[1] +
+             2. * (q[1] * q[3] - q[0] * q[2]) * v[2];
+  v_rot[1] = 2. * (q[1] * q[2] - q[0] * q[3]) * v[0] +
+             (q[0] * q[0] - q[1] * q[1] + q[2] * q[2] - q[3] * q[3]) * v[1] +
+             2. * (q[2] * q[3] + q[0] * q[1]) * v[2];
+  v_rot[2] = 2. * (q[1] * q[3] + q[0] * q[2]) * v[0] +
+             2. * (q[2] * q[3] - q[0] * q[1]) * v[1] +
+             (q[0] * q[0] - q[1] * q[1] - q[2] * q[2] + q[3] * q[3]) * v[2];
 }
 
 /**
  * @brief Computes 3D cross product of two vectors and stores the result.
  */
 template <typename View1, typename View2, typename View3>
-KOKKOS_INLINE_FUNCTION void CrossProduct3(
-    const View1& a, const View2& b, View3& c
-) {
-    c[0] = a[1] * b[2] - a[2] * b[1];
-    c[1] = a[2] * b[0] - a[0] * b[2];
-    c[2] = a[0] * b[1] - a[1] * b[0];
+KOKKOS_INLINE_FUNCTION void
+CrossProduct3(const View1& a, const View2& b, View3& c)
+{
+  c[0] = a[1] * b[2] - a[2] * b[1];
+  c[1] = a[2] * b[0] - a[0] * b[2];
+  c[2] = a[0] * b[1] - a[1] * b[0];
 }
 
 /**
@@ -63,18 +62,19 @@ KOKKOS_INLINE_FUNCTION void CrossProduct3(
  * @param bary_weights Output barycentric weights (size n)
  */
 KOKKOS_INLINE_FUNCTION
-inline void ComputeBarycentricWeights(
-    const double* KOKKOS_RESTRICT xs, int n, double* KOKKOS_RESTRICT bary_weights
-) {
-    for (int j = 0; j < n; ++j) {
-        double w = 1.0;
-        for (int m = 0; m < n; ++m) {
-            if (j != m) {
-                w /= (xs[j] - xs[m]);
-            }
-        }
-        bary_weights[j] = w;
+inline void
+ComputeBarycentricWeights(
+  const double* KOKKOS_RESTRICT xs, int n, double* KOKKOS_RESTRICT bary_weights)
+{
+  for (int j = 0; j < n; ++j) {
+    double w = 1.0;
+    for (int m = 0; m < n; ++m) {
+      if (j != m) {
+        w /= (xs[j] - xs[m]);
+      }
     }
+    bary_weights[j] = w;
+  }
 }
 
 /**
@@ -90,37 +90,38 @@ inline void ComputeBarycentricWeights(
  * @param weights Output interpolation basis weights (size n)
  */
 KOKKOS_INLINE_FUNCTION
-inline void LagrangePolynomialInterpWeights(
-    double x,
-    const double* KOKKOS_RESTRICT xs,
-    const double* KOKKOS_RESTRICT bary_weights,
-    int n,
-    double* KOKKOS_RESTRICT weights
-) {
-    constexpr double tol = 1.e-14;
+inline void
+LagrangePolynomialInterpWeights(
+  double x,
+  const double* KOKKOS_RESTRICT xs,
+  const double* KOKKOS_RESTRICT bary_weights,
+  int n,
+  double* KOKKOS_RESTRICT weights)
+{
+  constexpr double tol = 1.e-14;
 
-    // If x coincides with a node, return exact Kronecker-delta basis values.
-    for (int j = 0; j < n; ++j) {
-        if (std::abs(x - xs[j]) <= tol) {
-            for (int k = 0; k < n; ++k) {
-                weights[k] = 0.0;
-            }
-            weights[j] = 1.0;
-            return;
-        }
+  // If x coincides with a node, return exact Kronecker-delta basis values.
+  for (int j = 0; j < n; ++j) {
+    if (std::abs(x - xs[j]) <= tol) {
+      for (int k = 0; k < n; ++k) {
+        weights[k] = 0.0;
+      }
+      weights[j] = 1.0;
+      return;
     }
+  }
 
-    double denom = 0.0;
-    for (int j = 0; j < n; ++j) {
-        const double tmp = bary_weights[j] / (x - xs[j]);
-        weights[j] = tmp;
-        denom += tmp;
-    }
+  double denom = 0.0;
+  for (int j = 0; j < n; ++j) {
+    const double tmp = bary_weights[j] / (x - xs[j]);
+    weights[j] = tmp;
+    denom += tmp;
+  }
 
-    const double inv_denom = 1.0 / denom;
-    for (int j = 0; j < n; ++j) {
-        weights[j] *= inv_denom;
-    }
+  const double inv_denom = 1.0 / denom;
+  for (int j = 0; j < n; ++j) {
+    weights[j] *= inv_denom;
+  }
 }
 
 /**
@@ -139,56 +140,58 @@ inline void LagrangePolynomialInterpWeights(
  * @param dweights Output basis derivatives dl_j/dx (size n)
  */
 KOKKOS_INLINE_FUNCTION
-inline void LagrangePolynomialInterpWeightsAndDerivatives(
-    double x,
-    const double* KOKKOS_RESTRICT xs,
-    const double* KOKKOS_RESTRICT bary_weights,
-    int n,
-    double* KOKKOS_RESTRICT weights,
-    double* KOKKOS_RESTRICT dweights
-) {
-    constexpr double tol = 1.e-14;
+inline void
+LagrangePolynomialInterpWeightsAndDerivatives(
+  double x,
+  const double* KOKKOS_RESTRICT xs,
+  const double* KOKKOS_RESTRICT bary_weights,
+  int n,
+  double* KOKKOS_RESTRICT weights,
+  double* KOKKOS_RESTRICT dweights)
+{
+  constexpr double tol = 1.e-14;
 
-    // Exact-node case: l_m=1, l_j=0 for j!=m; use standard nodal derivative formula.
-    for (int j = 0; j < n; ++j) {
-        if (std::abs(x - xs[j]) <= tol) {
-            for (int k = 0; k < n; ++k) {
-                weights[k]  = 0.0;
-                dweights[k] = 0.0;
-            }
-            weights[j] = 1.0;
-            double sum_d = 0.0;
-            for (int k = 0; k < n; ++k) {
-                if (k != j) {
-                    dweights[k] = (bary_weights[k] / bary_weights[j]) / (xs[j] - xs[k]);
-                    sum_d += dweights[k];
-                }
-            }
-            dweights[j] = -sum_d;
-            return;
+  // Exact-node case: l_m=1, l_j=0 for j!=m; use standard nodal derivative
+  // formula.
+  for (int j = 0; j < n; ++j) {
+    if (std::abs(x - xs[j]) <= tol) {
+      for (int k = 0; k < n; ++k) {
+        weights[k] = 0.0;
+        dweights[k] = 0.0;
+      }
+      weights[j] = 1.0;
+      double sum_d = 0.0;
+      for (int k = 0; k < n; ++k) {
+        if (k != j) {
+          dweights[k] = (bary_weights[k] / bary_weights[j]) / (xs[j] - xs[k]);
+          sum_d += dweights[k];
         }
+      }
+      dweights[j] = -sum_d;
+      return;
     }
+  }
 
-    // General case: single-pass over nodes accumulates S and S2.
-    // S  = sum_k w_k/(x-x_k)   (barycentric denominator)
-    // S2 = sum_k w_k/(x-x_k)^2 (needed for derivative)
-    double S  = 0.0;
-    double S2 = 0.0;
-    for (int j = 0; j < n; ++j) {
-        const double diff = x - xs[j];
-        const double t    = bary_weights[j] / diff;
-        weights[j] = t;  // temporarily store t_j = w_j/(x-x_j)
-        S  += t;
-        S2 += t / diff;
-    }
+  // General case: single-pass over nodes accumulates S and S2.
+  // S  = sum_k w_k/(x-x_k)   (barycentric denominator)
+  // S2 = sum_k w_k/(x-x_k)^2 (needed for derivative)
+  double S = 0.0;
+  double S2 = 0.0;
+  for (int j = 0; j < n; ++j) {
+    const double diff = x - xs[j];
+    const double t = bary_weights[j] / diff;
+    weights[j] = t; // temporarily store t_j = w_j/(x-x_j)
+    S += t;
+    S2 += t / diff;
+  }
 
-    const double inv_S = 1.0 / S;
-    const double ratio = S2 * inv_S;  // S2/S, scalar shared across all j
-    for (int j = 0; j < n; ++j) {
-        const double lj = weights[j] * inv_S;
-        weights[j]  = lj;
-        dweights[j] = lj * (ratio - 1.0 / (x - xs[j]));
-    }
+  const double inv_S = 1.0 / S;
+  const double ratio = S2 * inv_S; // S2/S, scalar shared across all j
+  for (int j = 0; j < n; ++j) {
+    const double lj = weights[j] * inv_S;
+    weights[j] = lj;
+    dweights[j] = lj * (ratio - 1.0 / (x - xs[j]));
+  }
 }
 
 /**
@@ -203,36 +206,36 @@ inline void LagrangePolynomialInterpWeightsAndDerivatives(
  * @param output_bary_weights Precomputed barycentric weights for output_points
  * @param num_output_points Number of output points
  * @param scratch_weights Scratch array of size num_output_points
- * @param shape_functions Output flattened shape matrix [num_output_points * num_input_points]
+ * @param shape_functions Output flattened shape matrix [num_output_points *
+ * num_input_points]
  */
 KOKKOS_INLINE_FUNCTION
-inline void ComputeShapeFunctionValues(
-    const double* KOKKOS_RESTRICT input_points,
-    int num_input_points,
-    const double* KOKKOS_RESTRICT output_points,
-    const double* KOKKOS_RESTRICT output_bary_weights,
-    int num_output_points,
-    double* KOKKOS_RESTRICT scratch_weights,
-    double* KOKKOS_RESTRICT shape_functions
-) {
-    for (int input_point = 0; input_point < num_input_points; ++input_point) {
-        LagrangePolynomialInterpWeights(
-            input_points[input_point],
-            output_points,
-            output_bary_weights,
-            num_output_points,
-            scratch_weights
-        );
+inline void
+ComputeShapeFunctionValues(
+  const double* KOKKOS_RESTRICT input_points,
+  int num_input_points,
+  const double* KOKKOS_RESTRICT output_points,
+  const double* KOKKOS_RESTRICT output_bary_weights,
+  int num_output_points,
+  double* KOKKOS_RESTRICT scratch_weights,
+  double* KOKKOS_RESTRICT shape_functions)
+{
+  for (int input_point = 0; input_point < num_input_points; ++input_point) {
+    LagrangePolynomialInterpWeights(
+      input_points[input_point], output_points, output_bary_weights,
+      num_output_points, scratch_weights);
 
-        for (int output_point = 0; output_point < num_output_points; ++output_point) {
-            shape_functions[output_point * num_input_points + input_point] =
-                scratch_weights[output_point];
-        }
+    for (int output_point = 0; output_point < num_output_points;
+         ++output_point) {
+      shape_functions[output_point * num_input_points + input_point] =
+        scratch_weights[output_point];
     }
+  }
 }
 
 /**
- * @brief Interpolates a field at an evaluation point using Lagrange basis functions.
+ * @brief Interpolates a field at an evaluation point using Lagrange basis
+ * functions.
  *
  * Computes the interpolated value of a field at a given parametric coordinate
  * using precomputed barycentric weights and Lagrange basis functions.
@@ -241,74 +244,82 @@ inline void ComputeShapeFunctionValues(
  * @param node_xi Node parametric coordinates (size num_nodes)
  * @param node_field Node field values, layout [num_nodes][field_stride]
  * @param num_nodes Number of nodes
- * @param field_stride Number of components per node (e.g., 7 for position, 3 for displacement)
- * @param bary_weights Precomputed barycentric weights for node_xi (size num_nodes)
+ * @param field_stride Number of components per node (e.g., 7 for position, 3
+ * for displacement)
+ * @param bary_weights Precomputed barycentric weights for node_xi (size
+ * num_nodes)
  * @param scratch_weights Scratch array for basis functions (size num_nodes)
  * @param interp_field Output interpolated field (size field_stride)
  */
 KOKKOS_INLINE_FUNCTION
-inline void InterpolateFieldAtPoint(
-    double x_eval,
-    const double* KOKKOS_RESTRICT node_xi,
-    const double* KOKKOS_RESTRICT node_field,
-    int num_nodes,
-    int field_stride,
-    const double* KOKKOS_RESTRICT bary_weights,
-    double* KOKKOS_RESTRICT scratch_weights,
-    double* KOKKOS_RESTRICT interp_field
-) {
-    // Compute Lagrange basis weights at x_eval
-    LagrangePolynomialInterpWeights(x_eval, node_xi, bary_weights, num_nodes, scratch_weights);
+inline void
+InterpolateFieldAtPoint(
+  double x_eval,
+  const double* KOKKOS_RESTRICT node_xi,
+  const double* KOKKOS_RESTRICT node_field,
+  int num_nodes,
+  int field_stride,
+  const double* KOKKOS_RESTRICT bary_weights,
+  double* KOKKOS_RESTRICT scratch_weights,
+  double* KOKKOS_RESTRICT interp_field)
+{
+  // Compute Lagrange basis weights at x_eval
+  LagrangePolynomialInterpWeights(
+    x_eval, node_xi, bary_weights, num_nodes, scratch_weights);
 
-    // Initialize output to zero
+  // Initialize output to zero
+  for (int c = 0; c < field_stride; ++c) {
+    interp_field[c] = 0.0;
+  }
+
+  // Interpolate each component of the field
+  for (int j = 0; j < num_nodes; ++j) {
+    const double basis_j = scratch_weights[j];
     for (int c = 0; c < field_stride; ++c) {
-        interp_field[c] = 0.0;
+      interp_field[c] += basis_j * node_field[j * field_stride + c];
     }
-
-    // Interpolate each component of the field
-    for (int j = 0; j < num_nodes; ++j) {
-        const double basis_j = scratch_weights[j];
-        for (int c = 0; c < field_stride; ++c) {
-            interp_field[c] += basis_j * node_field[j * field_stride + c];
-        }
-    }
+  }
 }
 
 KOKKOS_INLINE_FUNCTION
-inline double SquaredDistance3(
-    const double* KOKKOS_RESTRICT a, const double* KOKKOS_RESTRICT b
-) {
-    const double dx = a[0] - b[0];
-    const double dy = a[1] - b[1];
-    const double dz = a[2] - b[2];
-    return dx * dx + dy * dy + dz * dz;
+inline double
+SquaredDistance3(
+  const double* KOKKOS_RESTRICT a, const double* KOKKOS_RESTRICT b)
+{
+  const double dx = a[0] - b[0];
+  const double dy = a[1] - b[1];
+  const double dz = a[2] - b[2];
+  return dx * dx + dy * dy + dz * dz;
 }
 
 KOKKOS_INLINE_FUNCTION
-inline double BladePointDistanceSquaredAtXi(
-    double xi,
-    const double* KOKKOS_RESTRICT query_point,
-    const double* KOKKOS_RESTRICT node_xi,
-    const double* KOKKOS_RESTRICT node_positions,
-    int num_nodes,
-    const double* KOKKOS_RESTRICT bary_weights,
-    double* KOKKOS_RESTRICT scratch_weights,
-    double* KOKKOS_RESTRICT interp_position
-) {
-    // Interpolate only xyz from node_positions[num_nodes][7] to reduce work in the hot path.
-    LagrangePolynomialInterpWeights(xi, node_xi, bary_weights, num_nodes, scratch_weights);
+inline double
+BladePointDistanceSquaredAtXi(
+  double xi,
+  const double* KOKKOS_RESTRICT query_point,
+  const double* KOKKOS_RESTRICT node_xi,
+  const double* KOKKOS_RESTRICT node_positions,
+  int num_nodes,
+  const double* KOKKOS_RESTRICT bary_weights,
+  double* KOKKOS_RESTRICT scratch_weights,
+  double* KOKKOS_RESTRICT interp_position)
+{
+  // Interpolate only xyz from node_positions[num_nodes][7] to reduce work in
+  // the hot path.
+  LagrangePolynomialInterpWeights(
+    xi, node_xi, bary_weights, num_nodes, scratch_weights);
 
-    interp_position[0] = 0.0;
-    interp_position[1] = 0.0;
-    interp_position[2] = 0.0;
-    for (int j = 0; j < num_nodes; ++j) {
-        const double basis_j = scratch_weights[j];
-        interp_position[0] += basis_j * node_positions[j * 7 + 0];
-        interp_position[1] += basis_j * node_positions[j * 7 + 1];
-        interp_position[2] += basis_j * node_positions[j * 7 + 2];
-    }
+  interp_position[0] = 0.0;
+  interp_position[1] = 0.0;
+  interp_position[2] = 0.0;
+  for (int j = 0; j < num_nodes; ++j) {
+    const double basis_j = scratch_weights[j];
+    interp_position[0] += basis_j * node_positions[j * 7 + 0];
+    interp_position[1] += basis_j * node_positions[j * 7 + 1];
+    interp_position[2] += basis_j * node_positions[j * 7 + 2];
+  }
 
-    return SquaredDistance3(interp_position, query_point);
+  return SquaredDistance3(interp_position, query_point);
 }
 
 /**
@@ -327,38 +338,36 @@ inline double BladePointDistanceSquaredAtXi(
  * @param scratch_dweights Scratch array size num_nodes (basis derivatives)
  */
 KOKKOS_INLINE_FUNCTION
-inline double BladePointFPrimeAtXi(
-    double xi,
-    const double* KOKKOS_RESTRICT query_point,
-    const double* KOKKOS_RESTRICT node_xi,
-    const double* KOKKOS_RESTRICT node_positions,
-    int num_nodes,
-    const double* KOKKOS_RESTRICT bary_weights,
-    double* KOKKOS_RESTRICT scratch_weights,
-    double* KOKKOS_RESTRICT scratch_dweights
-) {
-    LagrangePolynomialInterpWeightsAndDerivatives(
-        xi, node_xi, bary_weights, num_nodes, scratch_weights, scratch_dweights
-    );
+inline double
+BladePointFPrimeAtXi(
+  double xi,
+  const double* KOKKOS_RESTRICT query_point,
+  const double* KOKKOS_RESTRICT node_xi,
+  const double* KOKKOS_RESTRICT node_positions,
+  int num_nodes,
+  const double* KOKKOS_RESTRICT bary_weights,
+  double* KOKKOS_RESTRICT scratch_weights,
+  double* KOKKOS_RESTRICT scratch_dweights)
+{
+  LagrangePolynomialInterpWeightsAndDerivatives(
+    xi, node_xi, bary_weights, num_nodes, scratch_weights, scratch_dweights);
 
-    double r[3]      = {0.0, 0.0, 0.0};
-    double rprime[3] = {0.0, 0.0, 0.0};
-    for (int j = 0; j < num_nodes; ++j) {
-        const double lj  = scratch_weights[j];
-        const double dlj = scratch_dweights[j];
-        r[0]      += lj  * node_positions[j * 7 + 0];
-        r[1]      += lj  * node_positions[j * 7 + 1];
-        r[2]      += lj  * node_positions[j * 7 + 2];
-        rprime[0] += dlj * node_positions[j * 7 + 0];
-        rprime[1] += dlj * node_positions[j * 7 + 1];
-        rprime[2] += dlj * node_positions[j * 7 + 2];
-    }
+  double r[3] = {0.0, 0.0, 0.0};
+  double rprime[3] = {0.0, 0.0, 0.0};
+  for (int j = 0; j < num_nodes; ++j) {
+    const double lj = scratch_weights[j];
+    const double dlj = scratch_dweights[j];
+    r[0] += lj * node_positions[j * 7 + 0];
+    r[1] += lj * node_positions[j * 7 + 1];
+    r[2] += lj * node_positions[j * 7 + 2];
+    rprime[0] += dlj * node_positions[j * 7 + 0];
+    rprime[1] += dlj * node_positions[j * 7 + 1];
+    rprime[2] += dlj * node_positions[j * 7 + 2];
+  }
 
-    return 2.0 * (
-        (r[0] - query_point[0]) * rprime[0] +
-        (r[1] - query_point[1]) * rprime[1] +
-        (r[2] - query_point[2]) * rprime[2]
-    );
+  return 2.0 * ((r[0] - query_point[0]) * rprime[0] +
+                (r[1] - query_point[1]) * rprime[1] +
+                (r[2] - query_point[2]) * rprime[2]);
 }
 
 /**
@@ -380,105 +389,105 @@ inline double BladePointFPrimeAtXi(
  * @param out_dist2 Minimum squared distance
  */
 KOKKOS_INLINE_FUNCTION
-inline void FindClosestPointOnBlade(
-    const double* KOKKOS_RESTRICT query_point,
-    const double* KOKKOS_RESTRICT node_xi,
-    const double* KOKKOS_RESTRICT node_positions,
-    int num_nodes,
-    const double* KOKKOS_RESTRICT bary_weights,
-    double* KOKKOS_RESTRICT scratch_weights,
-    double* KOKKOS_RESTRICT scratch_dweights,
-    double& out_xi,
-    double* KOKKOS_RESTRICT out_position,
-    double& out_dist2
-) {
-    constexpr int    kCoarseSamples = 10;
-    constexpr int    kSecantIters   = 8;
-    constexpr double kXiMin         = -1.0;
-    constexpr double kXiMax         =  1.0;
+inline void
+FindClosestPointOnBlade(
+  const double* KOKKOS_RESTRICT query_point,
+  const double* KOKKOS_RESTRICT node_xi,
+  const double* KOKKOS_RESTRICT node_positions,
+  int num_nodes,
+  const double* KOKKOS_RESTRICT bary_weights,
+  double* KOKKOS_RESTRICT scratch_weights,
+  double* KOKKOS_RESTRICT scratch_dweights,
+  double& out_xi,
+  double* KOKKOS_RESTRICT out_position,
+  double& out_dist2)
+{
+  constexpr int kCoarseSamples = 10;
+  constexpr int kSecantIters = 8;
+  constexpr double kXiMin = -1.0;
+  constexpr double kXiMax = 1.0;
 
-    double interp_tmp[3];
+  double interp_tmp[3];
 
-    // Stage 1: coarse uniform scan to locate the bracket containing the minimum.
-    int    best_index = 0;
-    double best_xi    = kXiMin;
-    double best_dist2 = BladePointDistanceSquaredAtXi(
-        best_xi, query_point, node_xi, node_positions, num_nodes, bary_weights,
-        scratch_weights, interp_tmp
-    );
+  // Stage 1: coarse uniform scan to locate the bracket containing the minimum.
+  int best_index = 0;
+  double best_xi = kXiMin;
+  double best_dist2 = BladePointDistanceSquaredAtXi(
+    best_xi, query_point, node_xi, node_positions, num_nodes, bary_weights,
+    scratch_weights, interp_tmp);
 
-    for (int i = 1; i < kCoarseSamples; ++i) {
-        const double t  = static_cast<double>(i) / static_cast<double>(kCoarseSamples - 1);
-        const double xi = kXiMin + (kXiMax - kXiMin) * t;
-        const double d2 = BladePointDistanceSquaredAtXi(
-            xi, query_point, node_xi, node_positions, num_nodes, bary_weights,
-            scratch_weights, interp_tmp
-        );
-        if (d2 < best_dist2) {
-            best_dist2 = d2;
-            best_xi    = xi;
-            best_index = i;
-        }
+  for (int i = 1; i < kCoarseSamples; ++i) {
+    const double t =
+      static_cast<double>(i) / static_cast<double>(kCoarseSamples - 1);
+    const double xi = kXiMin + (kXiMax - kXiMin) * t;
+    const double d2 = BladePointDistanceSquaredAtXi(
+      xi, query_point, node_xi, node_positions, num_nodes, bary_weights,
+      scratch_weights, interp_tmp);
+    if (d2 < best_dist2) {
+      best_dist2 = d2;
+      best_xi = xi;
+      best_index = i;
     }
+  }
 
-    const int left_index  = (best_index > 0)                   ? (best_index - 1) : 0;
-    const int right_index = (best_index < kCoarseSamples - 1)  ? (best_index + 1) : (kCoarseSamples - 1);
+  const int left_index = (best_index > 0) ? (best_index - 1) : 0;
+  const int right_index =
+    (best_index < kCoarseSamples - 1) ? (best_index + 1) : (kCoarseSamples - 1);
 
-    double a = kXiMin + (kXiMax - kXiMin) * static_cast<double>(left_index)  / static_cast<double>(kCoarseSamples - 1);
-    double b = kXiMin + (kXiMax - kXiMin) * static_cast<double>(right_index) / static_cast<double>(kCoarseSamples - 1);
+  double a = kXiMin + (kXiMax - kXiMin) * static_cast<double>(left_index) /
+                        static_cast<double>(kCoarseSamples - 1);
+  double b = kXiMin + (kXiMax - kXiMin) * static_cast<double>(right_index) /
+                        static_cast<double>(kCoarseSamples - 1);
 
-    // Stage 2: bracketed secant on f'(xi) = 2*(r(xi)-q).r'(xi) = 0.
-    // The bracket [a, b] straddles the minimum so f'(a) <= 0 <= f'(b).
-    double fprime_a = BladePointFPrimeAtXi(
-        a, query_point, node_xi, node_positions, num_nodes, bary_weights,
-        scratch_weights, scratch_dweights
-    );
-    double fprime_b = BladePointFPrimeAtXi(
-        b, query_point, node_xi, node_positions, num_nodes, bary_weights,
-        scratch_weights, scratch_dweights
-    );
+  // Stage 2: bracketed secant on f'(xi) = 2*(r(xi)-q).r'(xi) = 0.
+  // The bracket [a, b] straddles the minimum so f'(a) <= 0 <= f'(b).
+  double fprime_a = BladePointFPrimeAtXi(
+    a, query_point, node_xi, node_positions, num_nodes, bary_weights,
+    scratch_weights, scratch_dweights);
+  double fprime_b = BladePointFPrimeAtXi(
+    b, query_point, node_xi, node_positions, num_nodes, bary_weights,
+    scratch_weights, scratch_dweights);
 
-    if (fprime_a * fprime_b >= 0.0) {
-        // Bracket has no sign change: minimum is at or very near a boundary.
-        // Fall back to the coarse-scan best.
-        out_xi = best_xi;
-    } else {
-        for (int iter = 0; iter < kSecantIters; ++iter) {
-            // Secant step: linear interpolation of f' to find its zero.
-            const double denom   = fprime_b - fprime_a;
-            const double xi_sec  = (std::abs(denom) > 1.e-30)
-                                   ? (a * fprime_b - b * fprime_a) / denom
-                                   : 0.5 * (a + b);
-            // Clamp to bracket as a safeguard.
-            const double xi_new  = Kokkos::min(b, Kokkos::max(a, xi_sec));
-            const double fprime_new = BladePointFPrimeAtXi(
-                xi_new, query_point, node_xi, node_positions, num_nodes, bary_weights,
-                scratch_weights, scratch_dweights
-            );
-            // Narrow the bracket.
-            if (fprime_new * fprime_a < 0.0) {
-                b        = xi_new;
-                fprime_b = fprime_new;
-            } else {
-                a        = xi_new;
-                fprime_a = fprime_new;
-            }
-            if (b - a < 1.e-12) break;
-        }
-        out_xi = 0.5 * (a + b);
+  if (fprime_a * fprime_b >= 0.0) {
+    // Bracket has no sign change: minimum is at or very near a boundary.
+    // Fall back to the coarse-scan best.
+    out_xi = best_xi;
+  } else {
+    for (int iter = 0; iter < kSecantIters; ++iter) {
+      // Secant step: linear interpolation of f' to find its zero.
+      const double denom = fprime_b - fprime_a;
+      const double xi_sec = (std::abs(denom) > 1.e-30)
+                              ? (a * fprime_b - b * fprime_a) / denom
+                              : 0.5 * (a + b);
+      // Clamp to bracket as a safeguard.
+      const double xi_new = Kokkos::min(b, Kokkos::max(a, xi_sec));
+      const double fprime_new = BladePointFPrimeAtXi(
+        xi_new, query_point, node_xi, node_positions, num_nodes, bary_weights,
+        scratch_weights, scratch_dweights);
+      // Narrow the bracket.
+      if (fprime_new * fprime_a < 0.0) {
+        b = xi_new;
+        fprime_b = fprime_new;
+      } else {
+        a = xi_new;
+        fprime_a = fprime_new;
+      }
+      if (b - a < 1.e-12)
+        break;
     }
+    out_xi = 0.5 * (a + b);
+  }
 
-    // Clamp to valid domain.
-    out_xi = Kokkos::min(kXiMax, Kokkos::max(kXiMin, out_xi));
+  // Clamp to valid domain.
+  out_xi = Kokkos::min(kXiMax, Kokkos::max(kXiMin, out_xi));
 
-    // Final position and distance at the converged xi.
-    out_dist2 = BladePointDistanceSquaredAtXi(
-        out_xi, query_point, node_xi, node_positions, num_nodes, bary_weights,
-        scratch_weights, interp_tmp
-    );
-    out_position[0] = interp_tmp[0];
-    out_position[1] = interp_tmp[1];
-    out_position[2] = interp_tmp[2];
+  // Final position and distance at the converged xi.
+  out_dist2 = BladePointDistanceSquaredAtXi(
+    out_xi, query_point, node_xi, node_positions, num_nodes, bary_weights,
+    scratch_weights, interp_tmp);
+  out_position[0] = interp_tmp[0];
+  out_position[1] = interp_tmp[1];
+  out_position[2] = interp_tmp[2];
 }
 
 } // namespace kynema_ugf

--- a/include/aero/fmb/KynemaFMBSixDof.h
+++ b/include/aero/fmb/KynemaFMBSixDof.h
@@ -65,7 +65,7 @@ public:
 
   void advance_struct_timestep(const double, const double) override;
 
-  void map_loads(const double) override;
+  void map_loads(const double currentTime) override;
 
   stk::mesh::PartVector get_mesh_blocks() const override
   {

--- a/include/aero/fsi/CalcLoadsAssembled.h
+++ b/include/aero/fsi/CalcLoadsAssembled.h
@@ -1,0 +1,54 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef CalcLoadsAssembled_h
+#define CalcLoadsAssembled_h
+
+#include <FieldTypeDef.h>
+
+// stk
+#include <stk_mesh/base/Part.hpp>
+
+namespace sierra {
+namespace kynema_ugf {
+
+class Realm;
+
+class CalcLoadsAssembled
+{
+public:
+  CalcLoadsAssembled(stk::mesh::PartVector& partVec, bool useShifted = true);
+  ~CalcLoadsAssembled();
+
+  void setup(std::shared_ptr<stk::mesh::BulkData> bulk);
+
+  void initialize();
+
+  void execute();
+
+  //! Part vector over all wall boundary parts applying loads
+  stk::mesh::PartVector partVec_;
+
+  const bool useShifted_;
+
+  std::shared_ptr<stk::mesh::BulkData> bulk_;
+
+  VectorFieldType* coordinates_;
+  ScalarFieldType* pressure_;
+  ScalarFieldType* density_;
+  ScalarFieldType* viscosity_;
+  TensorFieldType* dudx_;
+  GenericFieldType* exposedAreaVec_;
+  VectorFieldType* tforce_;
+};
+
+} // namespace kynema_ugf
+} // namespace sierra
+
+#endif

--- a/src/aero/CMakeLists.txt
+++ b/src/aero/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(${kynema_ugf_lib_name} PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/AeroContainer.C
   ${CMAKE_CURRENT_SOURCE_DIR}/CalcLoads.C
+  ${CMAKE_CURRENT_SOURCE_DIR}/CalcLoadsAssembled.C
 )
 
 if(ENABLE_KYNEMA_FMB_SIXDOF)

--- a/src/aero/CalcLoadsAssembled.C
+++ b/src/aero/CalcLoadsAssembled.C
@@ -1,0 +1,228 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+// kynema_ugf
+#include <aero/fsi/CalcLoadsAssembled.h>
+#include <Algorithm.h>
+#include <FieldTypeDef.h>
+#include <master_element/MasterElement.h>
+#include <master_element/MasterElementRepo.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+// basic c++
+#include <vector>
+
+namespace sierra {
+namespace kynema_ugf {
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// CalcLoadsAssembled - post process sigma_ijnjdS and pdS directly on the SCS's
+//    Mostly copied from SurfaceForceAndMomentAlgorithm after removing
+//    unnecessary parts
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+CalcLoadsAssembled::CalcLoadsAssembled(
+  stk::mesh::PartVector& partVec,
+  bool useShifted)
+  : partVec_(partVec),
+    useShifted_(useShifted),
+    coordinates_(NULL),
+    pressure_(NULL),
+    density_(NULL),
+    viscosity_(NULL),
+    dudx_(NULL),
+    exposedAreaVec_(NULL),
+    tforce_(NULL)
+{
+}
+
+void
+CalcLoadsAssembled::setup(std::shared_ptr<stk::mesh::BulkData> bulk)
+{
+  bulk_ = bulk;
+}
+
+void
+CalcLoadsAssembled::initialize()
+{
+
+  auto& meta = bulk_->mesh_meta_data();
+  coordinates_ =
+    meta.get_field<double>(stk::topology::NODE_RANK, "current_coordinates");
+  pressure_ = meta.get_field<double>(stk::topology::NODE_RANK, "pressure");
+  density_ = meta.get_field<double>(stk::topology::NODE_RANK, "density");
+  viscosity_ =
+    meta.get_field<double>(stk::topology::NODE_RANK, "effective_viscosity_u");
+
+  if (viscosity_ == nullptr) {
+    viscosity_ = meta.get_field<double>(stk::topology::NODE_RANK, "viscosity");
+  }
+  dudx_ = meta.get_field<double>(stk::topology::NODE_RANK, "dudx");
+
+  exposedAreaVec_ =
+    meta.get_field<double>(meta.side_rank(), "exposed_area_vector");
+  tforce_ = meta.get_field<double>(stk::topology::NODE_RANK, "tforce");
+}
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+CalcLoadsAssembled::~CalcLoadsAssembled()
+{
+  // does nothing
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+CalcLoadsAssembled::execute()
+{
+
+  // common
+  auto& meta = bulk_->mesh_meta_data();
+  const int nDim = meta.spatial_dimension();
+
+  // nodal fields to gather
+  std::vector<double> ws_pressure;
+  std::vector<double> ws_density;
+  std::vector<double> ws_viscosity;
+
+  // master element
+  std::vector<double> ws_face_shape_function;
+
+  // deal with state
+  ScalarFieldType& densityNp1 = density_->field_of_state(stk::mesh::StateNP1);
+
+  pressure_->sync_to_host();
+  density_->sync_to_host();
+  densityNp1.sync_to_host();
+  viscosity_->sync_to_host();
+  exposedAreaVec_->sync_to_host();
+  tforce_->sync_to_host();
+  coordinates_->sync_to_host();
+  dudx_->sync_to_host();
+
+  const auto& bkts = bulk_->get_buckets(
+    meta.side_rank(),
+    meta.locally_owned_part() & stk::mesh::selectUnion(partVec_));
+  for (auto b : bkts) {
+
+    // face master element
+    MasterElement* meFC =
+      sierra::kynema_ugf::MasterElementRepo::get_surface_master_element_on_host(
+        b->topology());
+    const int nodesPerFace = meFC->nodesPerElement_;
+    const int numScsBip = meFC->num_integration_points();
+
+    // mapping from ip to nodes for this ordinal; face perspective (use with
+    // face_node_relations)
+    const int* faceIpNodeMap = meFC->ipNodeMap();
+
+    // algorithm related; element
+    ws_pressure.resize(nodesPerFace);
+    ws_density.resize(nodesPerFace);
+    ws_viscosity.resize(nodesPerFace);
+    ws_face_shape_function.resize(numScsBip * nodesPerFace);
+
+    // pointers
+    double* p_pressure = &ws_pressure[0];
+    double* p_density = &ws_density[0];
+    double* p_viscosity = &ws_viscosity[0];
+    SharedMemView<double**, HostShmem> p_face_shape_function(
+      ws_face_shape_function.data(), numScsBip, nodesPerFace);
+
+    // shape functions
+    if (useShifted_)
+      meFC->shifted_shape_fcn<>(p_face_shape_function);
+    else
+      meFC->shape_fcn<>(p_face_shape_function);
+
+    const stk::mesh::Bucket::size_type length = b->size();
+
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+
+      // get face
+      stk::mesh::Entity face = (*b)[k];
+
+      // face node relations
+      stk::mesh::Entity const* face_node_rels = bulk_->begin_nodes(face);
+
+      //======================================
+      // gather nodal data off of face
+      //======================================
+      for (int ni = 0; ni < nodesPerFace; ++ni) {
+        stk::mesh::Entity node = face_node_rels[ni];
+        // gather scalars
+        p_pressure[ni] = *stk::mesh::field_data(*pressure_, node);
+        p_density[ni] = *stk::mesh::field_data(densityNp1, node);
+        p_viscosity[ni] = *stk::mesh::field_data(*viscosity_, node);
+      }
+
+      // pointer to face data
+      const double* areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
+
+      for (int ip = 0; ip < numScsBip; ++ip) {
+
+        // offsets
+        const int offSetAveraVec = ip * nDim;
+        const int localFaceNode = faceIpNodeMap[ip];
+
+        // interpolate to bip
+        double pBip = 0.0;
+        // double rhoBip = 0.0;
+        double muBip = 0.0;
+        for (int ic = 0; ic < nodesPerFace; ++ic) {
+          const double r = p_face_shape_function(ip, ic);
+          pBip += r * p_pressure[ic];
+          // rhoBip += r * p_density[ic];
+          muBip += r * p_viscosity[ic];
+        }
+
+        // extract nodal fields
+        stk::mesh::Entity node = face_node_rels[localFaceNode];
+        const double* duidxj = stk::mesh::field_data(*dudx_, node);
+        double * tforce = stk::mesh::field_data(*tforce_, node);
+
+        // divU and aMag
+        double divU = 0.0;
+        for (int j = 0; j < nDim; ++j)
+          divU += duidxj[j * nDim + j];
+
+        // assemble force -sigma_ij*njdS
+        for (int i = 0; i < nDim; ++i) {
+          const double ai = areaVec[offSetAveraVec + i];
+          double dflux = 0.0;
+          const int offSetI = nDim * i;
+          for (int j = 0; j < nDim; ++j) {
+            const int offSetTrans = nDim * j + i;
+            dflux += -muBip * (duidxj[offSetI + j] + duidxj[offSetTrans]) *
+                     areaVec[offSetAveraVec + j];
+          }
+          tforce[i] =
+            pBip * ai + dflux + 2.0 / 3.0 * muBip * divU * ai;
+        }
+      }
+    }
+  }
+  tforce_->modify_on_host();
+}
+
+} // namespace kynema_ugf
+} // namespace sierra

--- a/src/aero/CalcLoadsAssembled.C
+++ b/src/aero/CalcLoadsAssembled.C
@@ -39,8 +39,7 @@ namespace kynema_ugf {
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 CalcLoadsAssembled::CalcLoadsAssembled(
-  stk::mesh::PartVector& partVec,
-  bool useShifted)
+  stk::mesh::PartVector& partVec, bool useShifted)
   : partVec_(partVec),
     useShifted_(useShifted),
     coordinates_(NULL),
@@ -198,7 +197,7 @@ CalcLoadsAssembled::execute()
         // extract nodal fields
         stk::mesh::Entity node = face_node_rels[localFaceNode];
         const double* duidxj = stk::mesh::field_data(*dudx_, node);
-        double * tforce = stk::mesh::field_data(*tforce_, node);
+        double* tforce = stk::mesh::field_data(*tforce_, node);
 
         // divU and aMag
         double divU = 0.0;
@@ -215,8 +214,7 @@ CalcLoadsAssembled::execute()
             dflux += -muBip * (duidxj[offSetI + j] + duidxj[offSetTrans]) *
                      areaVec[offSetAveraVec + j];
           }
-          tforce[i] =
-            pBip * ai + dflux + 2.0 / 3.0 * muBip * divU * ai;
+          tforce[i] = pBip * ai + dflux + 2.0 / 3.0 * muBip * divU * ai;
         }
       }
     }

--- a/src/aero/fmb/KynemaFMBBase.C
+++ b/src/aero/fmb/KynemaFMBBase.C
@@ -1,6 +1,13 @@
 #include "aero/fmb/KynemaFMBBase.h"
+#include "aero/fmb/KynemaFMBBeamUtils.h"
 
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
+
+#include "stk_mesh/base/GetNgpMesh.hpp"
+#include "ngp_utils/NgpLoopUtils.h"
+#include "ngp_utils/NgpTypes.h"
 
 namespace sierra {
 
@@ -138,6 +145,308 @@ KynemaFMBBase::map_loads_point(PointMass& point)
     point.bulk->parallel());
 
   point.p_data.loads = forces_and_moments;
+}
+
+void
+KynemaFMBBase::compute_mapping_beam(BeamBody& beam)
+{
+  
+  Kokkos::deep_copy(beam.beam_data.node_xi, beam.beam_data_host.node_xi);
+  Kokkos::deep_copy(beam.beam_data.pos, beam.beam_data_host.pos);
+
+  constexpr int kMaxInterpolationNodes = 32;
+  auto node_xi_host = beam.beam_data_host.node_xi;
+  auto n_nodes = beam.n_nodes;
+  // Precompute barycentric weights for interpolation on xi-space nodes
+  ComputeBarycentricWeights(
+      node_xi_host.data(), static_cast<int>(n_nodes), beam.beam_data_host.bary_weights.data()
+  );
+  Kokkos::deep_copy(beam.beam_data.bary_weights, beam.beam_data_host.bary_weights);
+
+  auto& meta = beam.bulk->mesh_meta_data();
+  const auto& ngpMesh = stk::mesh::get_updated_ngp_mesh(*(beam.bulk));
+  const stk::mesh::EntityRank entityRank = stk::topology::NODE_RANK;
+
+  // get the parts in the current motion frame
+  stk::mesh::Selector sel =
+    stk::mesh::selectUnion(beam.moving_mesh_blocks) &
+    (meta.locally_owned_part() | meta.globally_shared_part());
+  // get the field from the NGP mesh
+  stk::mesh::NgpField<double> modelCoords =
+    stk::mesh::get_updated_ngp_field<double>(
+      *meta.get_field<double>(entityRank, "coordinates"));
+  stk::mesh::NgpField<double> beam_xi =
+    stk::mesh::get_updated_ngp_field<double>(
+      *meta.get_field<double>(entityRank, "beam_xi"));
+  modelCoords.sync_to_device();
+  beam_xi.sync_to_device();
+
+  auto positions = beam.beam_data.pos;
+  auto node_xi = beam.beam_data.node_xi;
+  auto bary_weights = beam.beam_data.bary_weights;
+
+  kynema_ugf_ngp::run_entity_algorithm(
+    "KynemaFMBBeam_compute_mapping", ngpMesh, entityRank, sel,
+    KOKKOS_LAMBDA(
+      const kynema_ugf_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex& mi) {
+
+      const double query_point[3] = {modelCoords(mi, 0), modelCoords(mi, 1), modelCoords(mi, 2)};
+      double scratch_weights[kMaxInterpolationNodes];
+      double scratch_dweights[kMaxInterpolationNodes];
+      double closest_position[3] = {0.0, 0.0, 0.0};
+      double xi = 0.0;
+      double dist2 = 0.0;
+
+      FindClosestPointOnBlade(
+          query_point,
+          node_xi.data(),
+          positions.data(),
+          n_nodes,
+          bary_weights.data(),
+          scratch_weights,
+          scratch_dweights,
+          xi,
+          closest_position,
+          dist2
+      );
+
+      beam_xi.get(mi,0) = xi;
+    });
+
+  beam_xi.modify_on_device();
+
+}
+
+void
+KynemaFMBBase::map_displacements_beam(BeamBody& beam, bool updateCur)
+{
+
+  Kokkos::deep_copy(beam.beam_data.disp, beam.beam_data_host.disp);
+  Kokkos::deep_copy(beam.beam_data.vel, beam.beam_data_host.vel);
+
+
+  constexpr int kMaxInterpolationNodes = 32;
+
+  auto& meta = beam.bulk->mesh_meta_data();
+  const auto& ngpMesh = stk::mesh::get_updated_ngp_mesh(*(beam.bulk));
+  const stk::mesh::EntityRank entityRank = stk::topology::NODE_RANK;
+
+  // get the parts in the current motion frame
+  stk::mesh::Selector sel =
+    stk::mesh::selectUnion(beam.moving_mesh_blocks) &
+    (meta.locally_owned_part() | meta.globally_shared_part());
+  // get the field from the NGP mesh
+  stk::mesh::NgpField<double> modelCoords =
+    stk::mesh::get_updated_ngp_field<double>(
+      *meta.get_field<double>(entityRank, "coordinates"));
+  stk::mesh::NgpField<double> curCoords =
+    stk::mesh::get_updated_ngp_field<double>(
+      *meta.get_field<double>(entityRank, "current_coordinates"));
+  stk::mesh::NgpField<double> meshDisp =
+    stk::mesh::get_updated_ngp_field<double>(
+      *meta.get_field<double>(entityRank, "mesh_displacement"));
+  stk::mesh::NgpField<double> meshVel =
+    stk::mesh::get_updated_ngp_field<double>(
+      *meta.get_field<double>(entityRank, "mesh_velocity"));
+  stk::mesh::NgpField<double> beam_xi =
+    stk::mesh::get_updated_ngp_field<double>(
+      *meta.get_field<double>(entityRank, "beam_xi"));
+
+  modelCoords.sync_to_device();
+  curCoords.sync_to_device();
+  meshDisp.sync_to_device();
+  meshVel.sync_to_device();
+  beam_xi.sync_to_device();
+
+  auto n_nodes = beam.n_nodes;
+
+  auto displacements = beam.beam_data.disp;
+  auto velocities = beam.beam_data.vel;
+  auto node_xi = beam.beam_data.node_xi;
+  auto positions = beam.beam_data.pos;
+  auto bary_weights = beam.beam_data.bary_weights;
+
+  kynema_ugf_ngp::run_entity_algorithm(
+    "KynemaFMBBeam_map_displacements", ngpMesh, entityRank, sel,
+    KOKKOS_LAMBDA(
+      const kynema_ugf_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex& mi) {
+
+      double scratch_weights[kMaxInterpolationNodes];
+      double pos[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+      double disp[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+      double vel[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+      const double xi = beam_xi.get(mi, 0);
+      double qp[3] = {modelCoords(mi, 0), modelCoords(mi, 1), modelCoords(mi, 2)};
+
+      InterpolateFieldAtPoint(
+          xi,
+          node_xi.data(),
+          positions.data(),
+          n_nodes,
+          7,
+          bary_weights.data(),
+          scratch_weights,
+          pos
+      );
+      InterpolateFieldAtPoint(
+          xi,
+          node_xi.data(),
+          displacements.data(),
+          n_nodes,
+          7,
+          bary_weights.data(),
+          scratch_weights,
+          disp
+      );
+        InterpolateFieldAtPoint(
+          xi,
+          node_xi.data(),
+          velocities.data(),
+          n_nodes,
+          6,
+          bary_weights.data(),
+          scratch_weights,
+          vel
+        );
+
+      double rel_pos_g[3] = {qp[0] - pos[0], qp[1] - pos[1], qp[2] - pos[2]};
+      double rel_pos_l[3] = {0.0, 0.0, 0.0};
+      RotateVectorByQuaternionInv(pos + 3, rel_pos_g, rel_pos_l);
+
+      double tmp_disp[3] = {0.0, 0.0, 0.0};
+      double rot_disp[3] = {0.0, 0.0, 0.0};
+      RotateVectorByQuaternion(disp + 3, rel_pos_l, tmp_disp);
+      RotateVectorByQuaternion(pos + 3, tmp_disp, rot_disp);
+
+      meshDisp.get(mi, 0) = disp[0] + rot_disp[0] - rel_pos_g[0];
+      meshDisp.get(mi, 1) = disp[1] + rot_disp[1] - rel_pos_g[1];
+      meshDisp.get(mi, 2) = disp[2] + rot_disp[2] - rel_pos_g[2];
+
+      const double omega_x = vel[3];
+      const double omega_y = vel[4];
+      const double omega_z = vel[5];
+      const double rot_vx = omega_y * rot_disp[2] - omega_z * rot_disp[1];
+      const double rot_vy = omega_z * rot_disp[0] - omega_x * rot_disp[2];
+      const double rot_vz = omega_x * rot_disp[1] - omega_y * rot_disp[0];
+      meshVel.get(mi, 0) = vel[0] + rot_vx;
+      meshVel.get(mi, 1) = vel[1] + rot_vy;
+      meshVel.get(mi, 2) = vel[2] + rot_vz;
+
+      if (updateCur) {
+        curCoords.get(mi, 0) = modelCoords(mi, 0) + meshDisp.get(mi, 0);
+        curCoords.get(mi, 1) = modelCoords(mi, 1) + meshDisp.get(mi, 1);
+        curCoords.get(mi, 2) = modelCoords(mi, 2) + meshDisp.get(mi, 2);
+      }
+    });
+
+  meshDisp.modify_on_device();
+  meshVel.modify_on_device();
+  curCoords.modify_on_device();
+}
+
+void
+KynemaFMBBase::map_loads_beam(BeamBody& beam)
+{
+  // First calculate the assembled forces on the beam surfaces
+  beam.calc_loads->initialize();
+  beam.calc_loads->execute();
+
+
+  auto& meta = beam.bulk->mesh_meta_data();
+  const auto& ngpMesh = stk::mesh::get_updated_ngp_mesh(*(beam.bulk));
+  const stk::mesh::EntityRank entityRank = stk::topology::NODE_RANK;
+    
+  // get the parts in the current motion frame
+  stk::mesh::Selector sel =
+    stk::mesh::selectUnion(beam.forcing_surfaces) &
+    (meta.locally_owned_part() | meta.globally_shared_part());
+  stk::mesh::NgpField<double> modelCoords =
+    stk::mesh::get_updated_ngp_field<double>(
+      *meta.get_field<double>(entityRank, "coordinates"));    
+  stk::mesh::NgpField<double> tforce =
+    stk::mesh::get_updated_ngp_field<double>(
+      *meta.get_field<double>(entityRank, "tforce"));
+  stk::mesh::NgpField<double> beam_xi =
+    stk::mesh::get_updated_ngp_field<double>(
+      *meta.get_field<double>(entityRank, "beam_xi"));      
+
+  tforce.sync_to_device();
+  beam_xi.sync_to_device();
+
+  constexpr int kMaxInterpolationNodes = 32;
+  auto n_nodes = beam.n_nodes;
+  auto bary_weights = beam.beam_data.bary_weights;
+  auto node_xi = beam.beam_data.node_xi;
+  auto positions = beam.beam_data.pos;
+
+  for (std::size_t i = 0; i < n_nodes; ++i) {
+    for (std::size_t j = 0; j < 6; ++j) {
+      beam.beam_data_host.loads(i, j) = 0.0;
+    }
+  }
+  Kokkos::deep_copy(beam.beam_data.loads, beam.beam_data_host.loads);
+  auto loads = beam.beam_data.loads;
+
+  kynema_ugf_ngp::run_entity_algorithm(
+    "KynemaFMBBeam_map_loads", ngpMesh, entityRank, sel,
+    KOKKOS_LAMBDA(
+      const kynema_ugf_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex& mi) {
+
+      const double query_point[3] = {modelCoords(mi, 0), modelCoords(mi, 1), modelCoords(mi, 2)};
+      double scratch_weights[kMaxInterpolationNodes];
+      double closest_position[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+      double xi = beam_xi.get(mi, 0);
+      const double force[3] = {tforce(mi, 0), tforce(mi, 1), tforce(mi, 2)};
+      double moment[3] = {0.0, 0.0, 0.0};
+
+      // Get the closest position on the beam to the query point and compute the relative position vector
+      // Relative position vector is expected to not change with beam deformation
+      InterpolateFieldAtPoint(
+          xi,
+          node_xi.data(),
+          positions.data(),
+          n_nodes,
+          7,
+          bary_weights.data(),
+          scratch_weights,
+          closest_position
+      );
+
+      double rel_pos[3] = {
+        query_point[0] - closest_position[0], 
+        query_point[1] - closest_position[1], 
+        query_point[2] - closest_position[2]};
+      
+      // Transferring force from beam surface to beam node will add moment
+      CrossProduct3(rel_pos, force, moment);
+
+      // Compute all shape functions for the current xi value to distribute the force and moment to all beam nodes
+      LagrangePolynomialInterpWeights(
+          xi,
+          node_xi.data(),
+          bary_weights.data(),
+          n_nodes,
+          scratch_weights
+      );
+
+      // Multiply the force and moment by the shape function weights and add to the loads on each beam node
+      for (std::size_t i = 0; i < n_nodes; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+          Kokkos::atomic_add(&loads(i,j), scratch_weights[i] * force[j]);
+          Kokkos::atomic_add(&loads(i,j+3), scratch_weights[i] * moment[j]);
+        }
+      }
+
+    });
+
+  Kokkos::fence();
+  Kokkos::deep_copy(beam.beam_data_host.loads, beam.beam_data.loads);
+
+  // Sum the loads across all ranks to get the total load on each beam node
+  MPI_Allreduce(
+    MPI_IN_PLACE, beam.beam_data_host.loads.data(), 6 * beam.n_nodes, MPI_DOUBLE, MPI_SUM,
+    beam.bulk->parallel());
+
 }
 
 } // namespace kynema_ugf

--- a/src/aero/fmb/KynemaFMBBase.C
+++ b/src/aero/fmb/KynemaFMBBase.C
@@ -150,7 +150,7 @@ KynemaFMBBase::map_loads_point(PointMass& point)
 void
 KynemaFMBBase::compute_mapping_beam(BeamBody& beam)
 {
-  
+
   Kokkos::deep_copy(beam.beam_data.node_xi, beam.beam_data_host.node_xi);
   Kokkos::deep_copy(beam.beam_data.pos, beam.beam_data_host.pos);
 
@@ -159,9 +159,10 @@ KynemaFMBBase::compute_mapping_beam(BeamBody& beam)
   auto n_nodes = beam.n_nodes;
   // Precompute barycentric weights for interpolation on xi-space nodes
   ComputeBarycentricWeights(
-      node_xi_host.data(), static_cast<int>(n_nodes), beam.beam_data_host.bary_weights.data()
-  );
-  Kokkos::deep_copy(beam.beam_data.bary_weights, beam.beam_data_host.bary_weights);
+    node_xi_host.data(), static_cast<int>(n_nodes),
+    beam.beam_data_host.bary_weights.data());
+  Kokkos::deep_copy(
+    beam.beam_data.bary_weights, beam.beam_data_host.bary_weights);
 
   auto& meta = beam.bulk->mesh_meta_data();
   const auto& ngpMesh = stk::mesh::get_updated_ngp_mesh(*(beam.bulk));
@@ -189,8 +190,8 @@ KynemaFMBBase::compute_mapping_beam(BeamBody& beam)
     "KynemaFMBBeam_compute_mapping", ngpMesh, entityRank, sel,
     KOKKOS_LAMBDA(
       const kynema_ugf_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex& mi) {
-
-      const double query_point[3] = {modelCoords(mi, 0), modelCoords(mi, 1), modelCoords(mi, 2)};
+      const double query_point[3] = {
+        modelCoords(mi, 0), modelCoords(mi, 1), modelCoords(mi, 2)};
       double scratch_weights[kMaxInterpolationNodes];
       double scratch_dweights[kMaxInterpolationNodes];
       double closest_position[3] = {0.0, 0.0, 0.0};
@@ -198,23 +199,14 @@ KynemaFMBBase::compute_mapping_beam(BeamBody& beam)
       double dist2 = 0.0;
 
       FindClosestPointOnBlade(
-          query_point,
-          node_xi.data(),
-          positions.data(),
-          n_nodes,
-          bary_weights.data(),
-          scratch_weights,
-          scratch_dweights,
-          xi,
-          closest_position,
-          dist2
-      );
+        query_point, node_xi.data(), positions.data(), n_nodes,
+        bary_weights.data(), scratch_weights, scratch_dweights, xi,
+        closest_position, dist2);
 
-      beam_xi.get(mi,0) = xi;
+      beam_xi.get(mi, 0) = xi;
     });
 
   beam_xi.modify_on_device();
-
 }
 
 void
@@ -223,7 +215,6 @@ KynemaFMBBase::map_displacements_beam(BeamBody& beam, bool updateCur)
 
   Kokkos::deep_copy(beam.beam_data.disp, beam.beam_data_host.disp);
   Kokkos::deep_copy(beam.beam_data.vel, beam.beam_data_host.vel);
-
 
   constexpr int kMaxInterpolationNodes = 32;
 
@@ -270,44 +261,23 @@ KynemaFMBBase::map_displacements_beam(BeamBody& beam, bool updateCur)
     "KynemaFMBBeam_map_displacements", ngpMesh, entityRank, sel,
     KOKKOS_LAMBDA(
       const kynema_ugf_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex& mi) {
-
       double scratch_weights[kMaxInterpolationNodes];
       double pos[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
       double disp[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
       double vel[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
       const double xi = beam_xi.get(mi, 0);
-      double qp[3] = {modelCoords(mi, 0), modelCoords(mi, 1), modelCoords(mi, 2)};
+      double qp[3] = {
+        modelCoords(mi, 0), modelCoords(mi, 1), modelCoords(mi, 2)};
 
       InterpolateFieldAtPoint(
-          xi,
-          node_xi.data(),
-          positions.data(),
-          n_nodes,
-          7,
-          bary_weights.data(),
-          scratch_weights,
-          pos
-      );
+        xi, node_xi.data(), positions.data(), n_nodes, 7, bary_weights.data(),
+        scratch_weights, pos);
       InterpolateFieldAtPoint(
-          xi,
-          node_xi.data(),
-          displacements.data(),
-          n_nodes,
-          7,
-          bary_weights.data(),
-          scratch_weights,
-          disp
-      );
-        InterpolateFieldAtPoint(
-          xi,
-          node_xi.data(),
-          velocities.data(),
-          n_nodes,
-          6,
-          bary_weights.data(),
-          scratch_weights,
-          vel
-        );
+        xi, node_xi.data(), displacements.data(), n_nodes, 7,
+        bary_weights.data(), scratch_weights, disp);
+      InterpolateFieldAtPoint(
+        xi, node_xi.data(), velocities.data(), n_nodes, 6, bary_weights.data(),
+        scratch_weights, vel);
 
       double rel_pos_g[3] = {qp[0] - pos[0], qp[1] - pos[1], qp[2] - pos[2]};
       double rel_pos_l[3] = {0.0, 0.0, 0.0};
@@ -351,24 +321,22 @@ KynemaFMBBase::map_loads_beam(BeamBody& beam)
   beam.calc_loads->initialize();
   beam.calc_loads->execute();
 
-
   auto& meta = beam.bulk->mesh_meta_data();
   const auto& ngpMesh = stk::mesh::get_updated_ngp_mesh(*(beam.bulk));
   const stk::mesh::EntityRank entityRank = stk::topology::NODE_RANK;
-    
+
   // get the parts in the current motion frame
   stk::mesh::Selector sel =
     stk::mesh::selectUnion(beam.forcing_surfaces) &
     (meta.locally_owned_part() | meta.globally_shared_part());
   stk::mesh::NgpField<double> modelCoords =
     stk::mesh::get_updated_ngp_field<double>(
-      *meta.get_field<double>(entityRank, "coordinates"));    
-  stk::mesh::NgpField<double> tforce =
-    stk::mesh::get_updated_ngp_field<double>(
-      *meta.get_field<double>(entityRank, "tforce"));
+      *meta.get_field<double>(entityRank, "coordinates"));
+  stk::mesh::NgpField<double> tforce = stk::mesh::get_updated_ngp_field<double>(
+    *meta.get_field<double>(entityRank, "tforce"));
   stk::mesh::NgpField<double> beam_xi =
     stk::mesh::get_updated_ngp_field<double>(
-      *meta.get_field<double>(entityRank, "beam_xi"));      
+      *meta.get_field<double>(entityRank, "beam_xi"));
 
   tforce.sync_to_device();
   beam_xi.sync_to_device();
@@ -391,52 +359,42 @@ KynemaFMBBase::map_loads_beam(BeamBody& beam)
     "KynemaFMBBeam_map_loads", ngpMesh, entityRank, sel,
     KOKKOS_LAMBDA(
       const kynema_ugf_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex& mi) {
-
-      const double query_point[3] = {modelCoords(mi, 0), modelCoords(mi, 1), modelCoords(mi, 2)};
+      const double query_point[3] = {
+        modelCoords(mi, 0), modelCoords(mi, 1), modelCoords(mi, 2)};
       double scratch_weights[kMaxInterpolationNodes];
       double closest_position[7] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
       double xi = beam_xi.get(mi, 0);
       const double force[3] = {tforce(mi, 0), tforce(mi, 1), tforce(mi, 2)};
       double moment[3] = {0.0, 0.0, 0.0};
 
-      // Get the closest position on the beam to the query point and compute the relative position vector
-      // Relative position vector is expected to not change with beam deformation
+      // Get the closest position on the beam to the query point and compute the
+      // relative position vector Relative position vector is expected to not
+      // change with beam deformation
       InterpolateFieldAtPoint(
-          xi,
-          node_xi.data(),
-          positions.data(),
-          n_nodes,
-          7,
-          bary_weights.data(),
-          scratch_weights,
-          closest_position
-      );
+        xi, node_xi.data(), positions.data(), n_nodes, 7, bary_weights.data(),
+        scratch_weights, closest_position);
 
       double rel_pos[3] = {
-        query_point[0] - closest_position[0], 
-        query_point[1] - closest_position[1], 
+        query_point[0] - closest_position[0],
+        query_point[1] - closest_position[1],
         query_point[2] - closest_position[2]};
-      
+
       // Transferring force from beam surface to beam node will add moment
       CrossProduct3(rel_pos, force, moment);
 
-      // Compute all shape functions for the current xi value to distribute the force and moment to all beam nodes
+      // Compute all shape functions for the current xi value to distribute the
+      // force and moment to all beam nodes
       LagrangePolynomialInterpWeights(
-          xi,
-          node_xi.data(),
-          bary_weights.data(),
-          n_nodes,
-          scratch_weights
-      );
+        xi, node_xi.data(), bary_weights.data(), n_nodes, scratch_weights);
 
-      // Multiply the force and moment by the shape function weights and add to the loads on each beam node
+      // Multiply the force and moment by the shape function weights and add to
+      // the loads on each beam node
       for (std::size_t i = 0; i < n_nodes; ++i) {
         for (std::size_t j = 0; j < 3; ++j) {
-          Kokkos::atomic_add(&loads(i,j), scratch_weights[i] * force[j]);
-          Kokkos::atomic_add(&loads(i,j+3), scratch_weights[i] * moment[j]);
+          Kokkos::atomic_add(&loads(i, j), scratch_weights[i] * force[j]);
+          Kokkos::atomic_add(&loads(i, j + 3), scratch_weights[i] * moment[j]);
         }
       }
-
     });
 
   Kokkos::fence();
@@ -444,9 +402,8 @@ KynemaFMBBase::map_loads_beam(BeamBody& beam)
 
   // Sum the loads across all ranks to get the total load on each beam node
   MPI_Allreduce(
-    MPI_IN_PLACE, beam.beam_data_host.loads.data(), 6 * beam.n_nodes, MPI_DOUBLE, MPI_SUM,
-    beam.bulk->parallel());
-
+    MPI_IN_PLACE, beam.beam_data_host.loads.data(), 6 * beam.n_nodes,
+    MPI_DOUBLE, MPI_SUM, beam.bulk->parallel());
 }
 
 } // namespace kynema_ugf

--- a/src/aero/fmb/KynemaFMBSixDof.C
+++ b/src/aero/fmb/KynemaFMBSixDof.C
@@ -439,7 +439,7 @@ KynemaFMBSixDof::map_displacements(double current_time, bool updateCurCoor)
 }
 
 void
-KynemaFMBSixDof::map_loads(const double)
+KynemaFMBSixDof::map_loads(const double /* current_time */)
 {
   for (int i = 0; i < (int)point_bodies_.size(); ++i) {
     map_loads_point(point_bodies_[i]);

--- a/unit_tests/aero/CMakeLists.txt
+++ b/unit_tests/aero/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestDisplacements.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestDeflectionRamping.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestPt2Line.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestKynemaFMBBase.C
 )
 
 if(ENABLE_OPENFAST)

--- a/unit_tests/aero/CMakeLists.txt
+++ b/unit_tests/aero/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestDeflectionRamping.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestPt2Line.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestKynemaFMBBase.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestKynemaFMBBeamUtils.C
 )
 
 if(ENABLE_OPENFAST)

--- a/unit_tests/aero/UnitTestKynemaFMBBase.C
+++ b/unit_tests/aero/UnitTestKynemaFMBBase.C
@@ -40,41 +40,46 @@ protected:
       stk::topology::NODE_RANK, "current_coordinates");
     meshDisp_ = &meta_->declare_field<double>(
       stk::topology::NODE_RANK, "mesh_displacement");
-    meshVelocity_ = &meta_->declare_field<double>(
-      stk::topology::NODE_RANK, "mesh_velocity");
-    beamXi_ = &meta_->declare_field<double>(
-      stk::topology::NODE_RANK, "beam_xi");
-    pressure_ = &meta_->declare_field<double>(
-      stk::topology::NODE_RANK, "pressure");
-    density_ = &meta_->declare_field<double>(
-      stk::topology::NODE_RANK, "density", 3);
+    meshVelocity_ =
+      &meta_->declare_field<double>(stk::topology::NODE_RANK, "mesh_velocity");
+    beamXi_ =
+      &meta_->declare_field<double>(stk::topology::NODE_RANK, "beam_xi");
+    pressure_ =
+      &meta_->declare_field<double>(stk::topology::NODE_RANK, "pressure");
+    density_ =
+      &meta_->declare_field<double>(stk::topology::NODE_RANK, "density", 3);
     viscosity_ = &meta_->declare_field<double>(
       stk::topology::NODE_RANK, "effective_viscosity_u");
     dudx_ = &meta_->declare_field<double>(stk::topology::NODE_RANK, "dudx");
     tforce_ = &meta_->declare_field<double>(stk::topology::NODE_RANK, "tforce");
-    exposedArea_ = &meta_->declare_field<double>(
-      meta_->side_rank(), "exposed_area_vector");
-    tforceScs_ = &meta_->declare_field<double>(
-      meta_->side_rank(), "tforce_scs");
+    exposedArea_ =
+      &meta_->declare_field<double>(meta_->side_rank(), "exposed_area_vector");
+    tforceScs_ =
+      &meta_->declare_field<double>(meta_->side_rank(), "tforce_scs");
 
     const double zero[3] = {0.0, 0.0, 0.0};
-    stk::mesh::put_field_on_mesh(*currentCoords_, meta_->universal_part(), 3, zero);
+    stk::mesh::put_field_on_mesh(
+      *currentCoords_, meta_->universal_part(), 3, zero);
     stk::mesh::put_field_on_mesh(*meshDisp_, meta_->universal_part(), 3, zero);
-    stk::mesh::put_field_on_mesh(*meshVelocity_, meta_->universal_part(), 3, zero);
+    stk::mesh::put_field_on_mesh(
+      *meshVelocity_, meta_->universal_part(), 3, zero);
     stk::mesh::put_field_on_mesh(*beamXi_, meta_->universal_part(), nullptr);
     stk::mesh::put_field_on_mesh(*pressure_, meta_->universal_part(), nullptr);
     stk::mesh::put_field_on_mesh(*density_, meta_->universal_part(), nullptr);
     stk::mesh::put_field_on_mesh(*viscosity_, meta_->universal_part(), nullptr);
     stk::mesh::put_field_on_mesh(*dudx_, meta_->universal_part(), 9, nullptr);
     stk::mesh::put_field_on_mesh(*tforce_, meta_->universal_part(), 3, zero);
-    stk::mesh::put_field_on_mesh(*exposedArea_, meta_->universal_part(), 12, nullptr);
-    stk::mesh::put_field_on_mesh(*tforceScs_, meta_->universal_part(), 12, nullptr);
+    stk::mesh::put_field_on_mesh(
+      *exposedArea_, meta_->universal_part(), 12, nullptr);
+    stk::mesh::put_field_on_mesh(
+      *tforceScs_, meta_->universal_part(), 12, nullptr);
 
     unit_test_utils::fill_hex8_mesh("generated:1x1x1|sideset:xXyYzZ", *bulk_);
     forcingSurface_ = meta_->get_part("surface_1");
-  EXPECT_NE(nullptr, forcingSurface_);
+    EXPECT_NE(nullptr, forcingSurface_);
 
-    const auto* coordinates = static_cast<const VectorFieldType*>(meta_->coordinate_field());
+    const auto* coordinates =
+      static_cast<const VectorFieldType*>(meta_->coordinate_field());
     for (const auto* bucket : bulk_->get_buckets(
            stk::topology::NODE_RANK, meta_->locally_owned_part())) {
       for (const auto node : *bucket) {
@@ -89,7 +94,8 @@ protected:
       }
     }
     for (const auto* bucket : bulk_->get_buckets(
-           meta_->side_rank(), meta_->locally_owned_part() & *forcingSurface_)) {
+           meta_->side_rank(),
+           meta_->locally_owned_part() & *forcingSurface_)) {
       for (const auto face : *bucket) {
         double* area = stk::mesh::field_data(*exposedArea_, face);
         for (int ip = 0; ip < 4; ++ip) {
@@ -114,7 +120,8 @@ protected:
     point.moving_mesh_blocks = {&meta_->universal_part()};
     point.forcing_surfaces = {forcingSurface_};
     point.total_force = tforceScs_;
-    point.calc_loads = std::make_shared<sierra::kynema_ugf::CalcLoads>(point.forcing_surfaces);
+    point.calc_loads =
+      std::make_shared<sierra::kynema_ugf::CalcLoads>(point.forcing_surfaces);
     point.calc_loads->setup(bulk_);
     return point;
   }
@@ -128,7 +135,8 @@ protected:
     beam.beam_data_host.resize(beam.n_nodes);
     beam.moving_mesh_blocks = {&meta_->universal_part()};
     beam.forcing_surfaces = {forcingSurface_};
-    beam.calc_loads = std::make_shared<sierra::kynema_ugf::CalcLoadsAssembled>(beam.forcing_surfaces);
+    beam.calc_loads = std::make_shared<sierra::kynema_ugf::CalcLoadsAssembled>(
+      beam.forcing_surfaces);
     beam.calc_loads->setup(bulk_);
     beam.beam_data_host.node_xi(0) = 0.0;
     beam.beam_data_host.node_xi(1) = 1.0;
@@ -183,7 +191,8 @@ TEST_F(KynemaFMBBaseTest, MapsPointDisplacementVelocityAndCurrentCoordinates)
   point.p_data.center_of_mass = {0.0, 0.0, 0.0};
 
   fmb_.map_displacements_point(point, false);
-  const auto* coordinates = static_cast<const VectorFieldType*>(meta_->coordinate_field());
+  const auto* coordinates =
+    static_cast<const VectorFieldType*>(meta_->coordinate_field());
   for (const auto* bucket : bulk_->get_buckets(
          stk::topology::NODE_RANK, meta_->locally_owned_part())) {
     for (const auto node : *bucket) {
@@ -224,7 +233,8 @@ TEST_F(KynemaFMBBaseTest, MapsBeamDisplacementsAfterComputingBeamCoordinates)
   fmb_.compute_mapping_beam(beam);
   fmb_.map_displacements_beam(beam, false);
   currentCoords_->sync_to_host();
-  const auto* coordinates = static_cast<const VectorFieldType*>(meta_->coordinate_field());
+  const auto* coordinates =
+    static_cast<const VectorFieldType*>(meta_->coordinate_field());
   for (const auto* bucket : bulk_->get_buckets(
          stk::topology::NODE_RANK, meta_->locally_owned_part())) {
     for (const auto node : *bucket) {

--- a/unit_tests/aero/UnitTestKynemaFMBBase.C
+++ b/unit_tests/aero/UnitTestKynemaFMBBase.C
@@ -1,0 +1,293 @@
+#include <gtest/gtest.h>
+
+#include <aero/fmb/KynemaFMBBase.h>
+
+#include "UnitTestUtils.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+using sierra::kynema_ugf::BeamBody;
+using sierra::kynema_ugf::KynemaFMBBase;
+using sierra::kynema_ugf::PointMass;
+using sierra::kynema_ugf::VectorFieldType;
+
+class TestFMB : public KynemaFMBBase
+{
+public:
+  void setup(double, std::shared_ptr<stk::mesh::BulkData>) override {}
+  void initialize(int, double) override {}
+  void map_displacements(double, bool) override {}
+  void advance_struct_timestep(double, double) override {}
+  void map_loads(double) override {}
+  stk::mesh::PartVector get_mesh_blocks() const override { return {}; }
+};
+
+class KynemaFMBBaseTest : public ::testing::Test
+{
+protected:
+  KynemaFMBBaseTest()
+  {
+    stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+    meshBuilder.set_spatial_dimension(3);
+    bulk_ = meshBuilder.create();
+    meta_ = &bulk_->mesh_meta_data();
+    meta_->use_simple_fields();
+
+    currentCoords_ = &meta_->declare_field<double>(
+      stk::topology::NODE_RANK, "current_coordinates");
+    meshDisp_ = &meta_->declare_field<double>(
+      stk::topology::NODE_RANK, "mesh_displacement");
+    meshVelocity_ = &meta_->declare_field<double>(
+      stk::topology::NODE_RANK, "mesh_velocity");
+    beamXi_ = &meta_->declare_field<double>(
+      stk::topology::NODE_RANK, "beam_xi");
+    pressure_ = &meta_->declare_field<double>(
+      stk::topology::NODE_RANK, "pressure");
+    density_ = &meta_->declare_field<double>(
+      stk::topology::NODE_RANK, "density", 3);
+    viscosity_ = &meta_->declare_field<double>(
+      stk::topology::NODE_RANK, "effective_viscosity_u");
+    dudx_ = &meta_->declare_field<double>(stk::topology::NODE_RANK, "dudx");
+    tforce_ = &meta_->declare_field<double>(stk::topology::NODE_RANK, "tforce");
+    exposedArea_ = &meta_->declare_field<double>(
+      meta_->side_rank(), "exposed_area_vector");
+    tforceScs_ = &meta_->declare_field<double>(
+      meta_->side_rank(), "tforce_scs");
+
+    const double zero[3] = {0.0, 0.0, 0.0};
+    stk::mesh::put_field_on_mesh(*currentCoords_, meta_->universal_part(), 3, zero);
+    stk::mesh::put_field_on_mesh(*meshDisp_, meta_->universal_part(), 3, zero);
+    stk::mesh::put_field_on_mesh(*meshVelocity_, meta_->universal_part(), 3, zero);
+    stk::mesh::put_field_on_mesh(*beamXi_, meta_->universal_part(), nullptr);
+    stk::mesh::put_field_on_mesh(*pressure_, meta_->universal_part(), nullptr);
+    stk::mesh::put_field_on_mesh(*density_, meta_->universal_part(), nullptr);
+    stk::mesh::put_field_on_mesh(*viscosity_, meta_->universal_part(), nullptr);
+    stk::mesh::put_field_on_mesh(*dudx_, meta_->universal_part(), 9, nullptr);
+    stk::mesh::put_field_on_mesh(*tforce_, meta_->universal_part(), 3, zero);
+    stk::mesh::put_field_on_mesh(*exposedArea_, meta_->universal_part(), 12, nullptr);
+    stk::mesh::put_field_on_mesh(*tforceScs_, meta_->universal_part(), 12, nullptr);
+
+    unit_test_utils::fill_hex8_mesh("generated:1x1x1|sideset:xXyYzZ", *bulk_);
+    forcingSurface_ = meta_->get_part("surface_1");
+  EXPECT_NE(nullptr, forcingSurface_);
+
+    const auto* coordinates = static_cast<const VectorFieldType*>(meta_->coordinate_field());
+    for (const auto* bucket : bulk_->get_buckets(
+           stk::topology::NODE_RANK, meta_->locally_owned_part())) {
+      for (const auto node : *bucket) {
+        const double* model = stk::mesh::field_data(*coordinates, node);
+        double* current = stk::mesh::field_data(*currentCoords_, node);
+        for (int component = 0; component < 3; ++component)
+          current[component] = model[component];
+        *stk::mesh::field_data(*pressure_, node) = 2.0;
+        *stk::mesh::field_data(*density_, node) = 1.0;
+        *stk::mesh::field_data(*viscosity_, node) = 0.0;
+        std::fill_n(stk::mesh::field_data(*dudx_, node), 9, 0.0);
+      }
+    }
+    for (const auto* bucket : bulk_->get_buckets(
+           meta_->side_rank(), meta_->locally_owned_part() & *forcingSurface_)) {
+      for (const auto face : *bucket) {
+        double* area = stk::mesh::field_data(*exposedArea_, face);
+        for (int ip = 0; ip < 4; ++ip) {
+          area[3 * ip] = 1.0;
+          area[3 * ip + 1] = 0.0;
+          area[3 * ip + 2] = 0.0;
+        }
+      }
+    }
+    currentCoords_->modify_on_host();
+    pressure_->modify_on_host();
+    density_->modify_on_host();
+    viscosity_->modify_on_host();
+    dudx_->modify_on_host();
+    exposedArea_->modify_on_host();
+  }
+
+  PointMass make_point_mass()
+  {
+    PointMass point;
+    point.bulk = bulk_;
+    point.moving_mesh_blocks = {&meta_->universal_part()};
+    point.forcing_surfaces = {forcingSurface_};
+    point.total_force = tforceScs_;
+    point.calc_loads = std::make_shared<sierra::kynema_ugf::CalcLoads>(point.forcing_surfaces);
+    point.calc_loads->setup(bulk_);
+    return point;
+  }
+
+  BeamBody make_beam_body()
+  {
+    BeamBody beam;
+    beam.bulk = bulk_;
+    beam.n_nodes = 2;
+    beam.beam_data.resize(beam.n_nodes);
+    beam.beam_data_host.resize(beam.n_nodes);
+    beam.moving_mesh_blocks = {&meta_->universal_part()};
+    beam.forcing_surfaces = {forcingSurface_};
+    beam.calc_loads = std::make_shared<sierra::kynema_ugf::CalcLoadsAssembled>(beam.forcing_surfaces);
+    beam.calc_loads->setup(bulk_);
+    beam.beam_data_host.node_xi(0) = 0.0;
+    beam.beam_data_host.node_xi(1) = 1.0;
+    beam.beam_data_host.pos(0, 0) = 0.0;
+    beam.beam_data_host.pos(1, 0) = 1.0;
+    for (int node = 0; node < 2; ++node) {
+      beam.beam_data_host.pos(node, 1) = 0.0;
+      beam.beam_data_host.pos(node, 2) = 0.0;
+      beam.beam_data_host.pos(node, 3) = 1.0;
+      beam.beam_data_host.pos(node, 4) = 0.0;
+      beam.beam_data_host.pos(node, 5) = 0.0;
+      beam.beam_data_host.pos(node, 6) = 0.0;
+      beam.beam_data_host.disp(node, 0) = 1.0;
+      beam.beam_data_host.disp(node, 1) = 2.0;
+      beam.beam_data_host.disp(node, 2) = 3.0;
+      beam.beam_data_host.disp(node, 3) = std::sqrt(0.5);
+      beam.beam_data_host.disp(node, 4) = 0.0;
+      beam.beam_data_host.disp(node, 5) = 0.0;
+      beam.beam_data_host.disp(node, 6) = std::sqrt(0.5);
+      beam.beam_data_host.vel(node, 0) = 4.0;
+      beam.beam_data_host.vel(node, 1) = 5.0;
+      beam.beam_data_host.vel(node, 2) = 6.0;
+      beam.beam_data_host.vel(node, 3) = 0.0;
+      beam.beam_data_host.vel(node, 4) = 0.0;
+      beam.beam_data_host.vel(node, 5) = 2.0;
+    }
+    return beam;
+  }
+
+  stk::mesh::MetaData* meta_{nullptr};
+  std::shared_ptr<stk::mesh::BulkData> bulk_;
+  stk::mesh::Part* forcingSurface_{nullptr};
+  VectorFieldType* currentCoords_{nullptr};
+  VectorFieldType* meshDisp_{nullptr};
+  VectorFieldType* meshVelocity_{nullptr};
+  sierra::kynema_ugf::ScalarFieldType* beamXi_{nullptr};
+  sierra::kynema_ugf::ScalarFieldType* pressure_{nullptr};
+  sierra::kynema_ugf::ScalarFieldType* density_{nullptr};
+  sierra::kynema_ugf::ScalarFieldType* viscosity_{nullptr};
+  sierra::kynema_ugf::GenericFieldType* dudx_{nullptr};
+  VectorFieldType* tforce_{nullptr};
+  sierra::kynema_ugf::GenericFieldType* exposedArea_{nullptr};
+  sierra::kynema_ugf::GenericFieldType* tforceScs_{nullptr};
+  TestFMB fmb_;
+};
+
+TEST_F(KynemaFMBBaseTest, MapsPointDisplacementVelocityAndCurrentCoordinates)
+{
+  auto point = make_point_mass();
+  point.p_data.pos = {1.0, 2.0, 3.0, std::sqrt(0.5), 0.0, 0.0, std::sqrt(0.5)};
+  point.p_data.vel = {4.0, 5.0, 6.0, 0.0, 0.0, 2.0};
+  point.p_data.center_of_mass = {0.0, 0.0, 0.0};
+
+  fmb_.map_displacements_point(point, false);
+  const auto* coordinates = static_cast<const VectorFieldType*>(meta_->coordinate_field());
+  for (const auto* bucket : bulk_->get_buckets(
+         stk::topology::NODE_RANK, meta_->locally_owned_part())) {
+    for (const auto node : *bucket) {
+      const double* model = stk::mesh::field_data(*coordinates, node);
+      const double* current = stk::mesh::field_data(*currentCoords_, node);
+      EXPECT_DOUBLE_EQ(model[0], current[0]);
+      EXPECT_DOUBLE_EQ(model[1], current[1]);
+      EXPECT_DOUBLE_EQ(model[2], current[2]);
+    }
+  }
+
+  fmb_.map_displacements_point(point, true);
+
+  for (const auto* bucket : bulk_->get_buckets(
+         stk::topology::NODE_RANK, meta_->locally_owned_part())) {
+    for (const auto node : *bucket) {
+      const double* model = stk::mesh::field_data(*coordinates, node);
+      const double* displacement = stk::mesh::field_data(*meshDisp_, node);
+      const double* velocity = stk::mesh::field_data(*meshVelocity_, node);
+      const double* current = stk::mesh::field_data(*currentCoords_, node);
+      EXPECT_NEAR(1.0 - model[0] - model[1], displacement[0], 1.e-12);
+      EXPECT_NEAR(2.0 + model[0] - model[1], displacement[1], 1.e-12);
+      EXPECT_NEAR(3.0, displacement[2], 1.e-12);
+      EXPECT_NEAR(4.0 - 2.0 * model[0], velocity[0], 1.e-12);
+      EXPECT_NEAR(5.0 - 2.0 * model[1], velocity[1], 1.e-12);
+      EXPECT_NEAR(6.0, velocity[2], 1.e-12);
+      EXPECT_NEAR(model[0] + displacement[0], current[0], 1.e-12);
+      EXPECT_NEAR(model[1] + displacement[1], current[1], 1.e-12);
+      EXPECT_NEAR(model[2] + displacement[2], current[2], 1.e-12);
+    }
+  }
+}
+
+TEST_F(KynemaFMBBaseTest, MapsBeamDisplacementsAfterComputingBeamCoordinates)
+{
+  auto beam = make_beam_body();
+
+  fmb_.compute_mapping_beam(beam);
+  fmb_.map_displacements_beam(beam, false);
+  currentCoords_->sync_to_host();
+  const auto* coordinates = static_cast<const VectorFieldType*>(meta_->coordinate_field());
+  for (const auto* bucket : bulk_->get_buckets(
+         stk::topology::NODE_RANK, meta_->locally_owned_part())) {
+    for (const auto node : *bucket) {
+      const double* model = stk::mesh::field_data(*coordinates, node);
+      const double* current = stk::mesh::field_data(*currentCoords_, node);
+      EXPECT_DOUBLE_EQ(model[0], current[0]);
+      EXPECT_DOUBLE_EQ(model[1], current[1]);
+      EXPECT_DOUBLE_EQ(model[2], current[2]);
+    }
+  }
+
+  fmb_.map_displacements_beam(beam, true);
+  beamXi_->sync_to_host();
+  meshDisp_->sync_to_host();
+  meshVelocity_->sync_to_host();
+  currentCoords_->sync_to_host();
+
+  for (const auto* bucket : bulk_->get_buckets(
+         stk::topology::NODE_RANK, meta_->locally_owned_part())) {
+    for (const auto node : *bucket) {
+      const double* model = stk::mesh::field_data(*coordinates, node);
+      const double* displacement = stk::mesh::field_data(*meshDisp_, node);
+      const double* velocity = stk::mesh::field_data(*meshVelocity_, node);
+      const double* current = stk::mesh::field_data(*currentCoords_, node);
+      const double xi = *stk::mesh::field_data(*beamXi_, node);
+      EXPECT_GE(xi, 0.0);
+      EXPECT_LE(xi, 1.0);
+      EXPECT_NEAR(1.0 + xi - model[0] - model[1], displacement[0], 1.e-12);
+      EXPECT_NEAR(2.0 + model[0] - xi - model[1], displacement[1], 1.e-12);
+      EXPECT_NEAR(3.0, displacement[2], 1.e-12);
+      EXPECT_NEAR(4.0 - 2.0 * (model[0] - xi), velocity[0], 1.e-12);
+      EXPECT_NEAR(5.0 - 2.0 * model[1], velocity[1], 1.e-12);
+      EXPECT_NEAR(6.0, velocity[2], 1.e-12);
+      EXPECT_NEAR(model[0] + displacement[0], current[0], 1.e-12);
+      EXPECT_NEAR(model[1] + displacement[1], current[1], 1.e-12);
+      EXPECT_NEAR(model[2] + displacement[2], current[2], 1.e-12);
+    }
+  }
+}
+
+TEST_F(KynemaFMBBaseTest, MapsPointLoadsWithCalcLoads)
+{
+  auto point = make_point_mass();
+  point.p_data.pos = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0};
+
+  fmb_.map_loads_point(point);
+
+  EXPECT_NEAR(48.0, point.p_data.loads[0], 1.e-12);
+  EXPECT_NEAR(0.0, point.p_data.loads[1], 1.e-12);
+  EXPECT_NEAR(0.0, point.p_data.loads[2], 1.e-12);
+}
+
+TEST_F(KynemaFMBBaseTest, MapsBeamLoadsWithCalcLoadsAssembled)
+{
+  auto beam = make_beam_body();
+  fmb_.compute_mapping_beam(beam);
+
+  fmb_.map_loads_beam(beam);
+
+  double totalForceX = 0.0;
+  for (std::size_t node = 0; node < beam.n_nodes; ++node)
+    totalForceX += beam.beam_data_host.loads(node, 0);
+  EXPECT_NEAR(16.0, totalForceX, 1.e-12);
+}
+
+} // namespace

--- a/unit_tests/aero/UnitTestKynemaFMBBeamUtils.C
+++ b/unit_tests/aero/UnitTestKynemaFMBBeamUtils.C
@@ -108,11 +108,13 @@ TEST(KynemaFMBBeamUtils, ComputesShapeFunctionsAndInterpolatesFields)
     linearNodes.data(), 2, linearBarycentricWeights.data());
   InterpolateFieldAtPoint(
     0.25, linearNodes.data(), field.data(), 2, 2,
-    linearBarycentricWeights.data(), scratchWeights.data(), interpolated.data());
+    linearBarycentricWeights.data(), scratchWeights.data(),
+    interpolated.data());
 
   for (int row = 0; row < 3; ++row) {
     for (int column = 0; column < 3; ++column) {
-      EXPECT_DOUBLE_EQ(row == column ? 1.0 : 0.0, shapeFunctions[3 * row + column]);
+      EXPECT_DOUBLE_EQ(
+        row == column ? 1.0 : 0.0, shapeFunctions[3 * row + column]);
     }
   }
   EXPECT_NEAR(1.25, interpolated[0], kTolerance);
@@ -122,9 +124,8 @@ TEST(KynemaFMBBeamUtils, ComputesShapeFunctionsAndInterpolatesFields)
 TEST(KynemaFMBBeamUtils, EvaluatesBladeDistanceAndDerivative)
 {
   const std::array<double, 2> nodes = {-1.0, 1.0};
-  const std::array<double, 14> positions = {
-    -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
-     1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0};
+  const std::array<double, 14> positions = {-1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+                                            1.0,  0.0, 0.0, 1.0, 0.0, 0.0, 0.0};
   const std::array<double, 3> query = {0.25, 2.0, -1.0};
   std::array<double, 2> barycentricWeights{};
   std::array<double, 2> scratchWeights{};
@@ -134,25 +135,28 @@ TEST(KynemaFMBBeamUtils, EvaluatesBladeDistanceAndDerivative)
   ComputeBarycentricWeights(nodes.data(), 2, barycentricWeights.data());
   const double distanceSquared = BladePointDistanceSquaredAtXi(
     0.25, query.data(), nodes.data(), positions.data(), 2,
-    barycentricWeights.data(), scratchWeights.data(), interpolatedPosition.data());
+    barycentricWeights.data(), scratchWeights.data(),
+    interpolatedPosition.data());
   const double derivative = BladePointFPrimeAtXi(
     0.0, query.data(), nodes.data(), positions.data(), 2,
-    barycentricWeights.data(), scratchWeights.data(), scratchDerivatives.data());
+    barycentricWeights.data(), scratchWeights.data(),
+    scratchDerivatives.data());
 
   EXPECT_NEAR(5.0, distanceSquared, kTolerance);
   EXPECT_NEAR(0.25, interpolatedPosition[0], kTolerance);
   EXPECT_NEAR(0.0, interpolatedPosition[1], kTolerance);
   EXPECT_NEAR(0.0, interpolatedPosition[2], kTolerance);
   EXPECT_NEAR(-0.5, derivative, kTolerance);
-  EXPECT_NEAR(5.0, SquaredDistance3(interpolatedPosition.data(), query.data()), kTolerance);
+  EXPECT_NEAR(
+    5.0, SquaredDistance3(interpolatedPosition.data(), query.data()),
+    kTolerance);
 }
 
 TEST(KynemaFMBBeamUtils, FindsInteriorAndEndpointClosestPoints)
 {
   const std::array<double, 2> nodes = {-1.0, 1.0};
-  const std::array<double, 14> positions = {
-    -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
-     1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0};
+  const std::array<double, 14> positions = {-1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+                                            1.0,  0.0, 0.0, 1.0, 0.0, 0.0, 0.0};
   std::array<double, 2> barycentricWeights{};
   std::array<double, 2> scratchWeights{};
   std::array<double, 2> scratchDerivatives{};

--- a/unit_tests/aero/UnitTestKynemaFMBBeamUtils.C
+++ b/unit_tests/aero/UnitTestKynemaFMBBeamUtils.C
@@ -1,0 +1,183 @@
+#include <gtest/gtest.h>
+
+#include <aero/fmb/KynemaFMBBeamUtils.h>
+
+#include <array>
+#include <cmath>
+
+namespace {
+
+using namespace sierra::kynema_ugf;
+
+constexpr double kTolerance = 1.e-12;
+
+TEST(KynemaFMBBeamUtils, RotatesVectorsAndComputesCrossProduct)
+{
+  const std::array<double, 4> rotation = {
+    std::sqrt(0.5), 0.0, 0.0, std::sqrt(0.5)};
+  const std::array<double, 3> vector = {1.0, 0.0, 0.0};
+  std::array<double, 3> rotated{};
+  std::array<double, 3> recovered{};
+  std::array<double, 3> crossProduct{};
+
+  RotateVectorByQuaternion(rotation, vector, rotated);
+  RotateVectorByQuaternionInv(rotation, rotated, recovered);
+  CrossProduct3(vector, rotated, crossProduct);
+
+  EXPECT_NEAR(0.0, rotated[0], kTolerance);
+  EXPECT_NEAR(1.0, rotated[1], kTolerance);
+  EXPECT_NEAR(0.0, rotated[2], kTolerance);
+  EXPECT_NEAR(vector[0], recovered[0], kTolerance);
+  EXPECT_NEAR(vector[1], recovered[1], kTolerance);
+  EXPECT_NEAR(vector[2], recovered[2], kTolerance);
+  EXPECT_NEAR(0.0, crossProduct[0], kTolerance);
+  EXPECT_NEAR(0.0, crossProduct[1], kTolerance);
+  EXPECT_NEAR(1.0, crossProduct[2], kTolerance);
+}
+
+TEST(KynemaFMBBeamUtils, ComputesBarycentricWeightsAndBasisValues)
+{
+  const std::array<double, 3> nodes = {-1.0, 0.0, 1.0};
+  std::array<double, 3> barycentricWeights{};
+  std::array<double, 3> weights{};
+
+  ComputeBarycentricWeights(nodes.data(), 3, barycentricWeights.data());
+  LagrangePolynomialInterpWeights(
+    0.5, nodes.data(), barycentricWeights.data(), 3, weights.data());
+
+  EXPECT_NEAR(0.5, barycentricWeights[0], kTolerance);
+  EXPECT_NEAR(-1.0, barycentricWeights[1], kTolerance);
+  EXPECT_NEAR(0.5, barycentricWeights[2], kTolerance);
+  EXPECT_NEAR(-0.125, weights[0], kTolerance);
+  EXPECT_NEAR(0.75, weights[1], kTolerance);
+  EXPECT_NEAR(0.375, weights[2], kTolerance);
+
+  LagrangePolynomialInterpWeights(
+    0.0, nodes.data(), barycentricWeights.data(), 3, weights.data());
+  EXPECT_DOUBLE_EQ(0.0, weights[0]);
+  EXPECT_DOUBLE_EQ(1.0, weights[1]);
+  EXPECT_DOUBLE_EQ(0.0, weights[2]);
+}
+
+TEST(KynemaFMBBeamUtils, ComputesBasisDerivativesAtInteriorAndNodalPoints)
+{
+  const std::array<double, 3> nodes = {-1.0, 0.0, 1.0};
+  std::array<double, 3> barycentricWeights{};
+  std::array<double, 3> weights{};
+  std::array<double, 3> derivatives{};
+
+  ComputeBarycentricWeights(nodes.data(), 3, barycentricWeights.data());
+  LagrangePolynomialInterpWeightsAndDerivatives(
+    0.5, nodes.data(), barycentricWeights.data(), 3, weights.data(),
+    derivatives.data());
+
+  EXPECT_NEAR(-0.125, weights[0], kTolerance);
+  EXPECT_NEAR(0.75, weights[1], kTolerance);
+  EXPECT_NEAR(0.375, weights[2], kTolerance);
+  EXPECT_NEAR(0.0, derivatives[0], kTolerance);
+  EXPECT_NEAR(-1.0, derivatives[1], kTolerance);
+  EXPECT_NEAR(1.0, derivatives[2], kTolerance);
+
+  LagrangePolynomialInterpWeightsAndDerivatives(
+    0.0, nodes.data(), barycentricWeights.data(), 3, weights.data(),
+    derivatives.data());
+  EXPECT_DOUBLE_EQ(0.0, weights[0]);
+  EXPECT_DOUBLE_EQ(1.0, weights[1]);
+  EXPECT_DOUBLE_EQ(0.0, weights[2]);
+  EXPECT_NEAR(-0.5, derivatives[0], kTolerance);
+  EXPECT_NEAR(0.0, derivatives[1], kTolerance);
+  EXPECT_NEAR(0.5, derivatives[2], kTolerance);
+}
+
+TEST(KynemaFMBBeamUtils, ComputesShapeFunctionsAndInterpolatesFields)
+{
+  const std::array<double, 3> nodes = {-1.0, 0.0, 1.0};
+  std::array<double, 3> barycentricWeights{};
+  std::array<double, 3> scratchWeights{};
+  std::array<double, 9> shapeFunctions{};
+  const std::array<double, 4> field = {0.0, 10.0, 2.0, 20.0};
+  const std::array<double, 2> linearNodes = {-1.0, 1.0};
+  std::array<double, 2> linearBarycentricWeights{};
+  std::array<double, 2> interpolated{};
+
+  ComputeBarycentricWeights(nodes.data(), 3, barycentricWeights.data());
+  ComputeShapeFunctionValues(
+    nodes.data(), 3, nodes.data(), barycentricWeights.data(), 3,
+    scratchWeights.data(), shapeFunctions.data());
+  ComputeBarycentricWeights(
+    linearNodes.data(), 2, linearBarycentricWeights.data());
+  InterpolateFieldAtPoint(
+    0.25, linearNodes.data(), field.data(), 2, 2,
+    linearBarycentricWeights.data(), scratchWeights.data(), interpolated.data());
+
+  for (int row = 0; row < 3; ++row) {
+    for (int column = 0; column < 3; ++column) {
+      EXPECT_DOUBLE_EQ(row == column ? 1.0 : 0.0, shapeFunctions[3 * row + column]);
+    }
+  }
+  EXPECT_NEAR(1.25, interpolated[0], kTolerance);
+  EXPECT_NEAR(16.25, interpolated[1], kTolerance);
+}
+
+TEST(KynemaFMBBeamUtils, EvaluatesBladeDistanceAndDerivative)
+{
+  const std::array<double, 2> nodes = {-1.0, 1.0};
+  const std::array<double, 14> positions = {
+    -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+     1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0};
+  const std::array<double, 3> query = {0.25, 2.0, -1.0};
+  std::array<double, 2> barycentricWeights{};
+  std::array<double, 2> scratchWeights{};
+  std::array<double, 2> scratchDerivatives{};
+  std::array<double, 3> interpolatedPosition{};
+
+  ComputeBarycentricWeights(nodes.data(), 2, barycentricWeights.data());
+  const double distanceSquared = BladePointDistanceSquaredAtXi(
+    0.25, query.data(), nodes.data(), positions.data(), 2,
+    barycentricWeights.data(), scratchWeights.data(), interpolatedPosition.data());
+  const double derivative = BladePointFPrimeAtXi(
+    0.0, query.data(), nodes.data(), positions.data(), 2,
+    barycentricWeights.data(), scratchWeights.data(), scratchDerivatives.data());
+
+  EXPECT_NEAR(5.0, distanceSquared, kTolerance);
+  EXPECT_NEAR(0.25, interpolatedPosition[0], kTolerance);
+  EXPECT_NEAR(0.0, interpolatedPosition[1], kTolerance);
+  EXPECT_NEAR(0.0, interpolatedPosition[2], kTolerance);
+  EXPECT_NEAR(-0.5, derivative, kTolerance);
+  EXPECT_NEAR(5.0, SquaredDistance3(interpolatedPosition.data(), query.data()), kTolerance);
+}
+
+TEST(KynemaFMBBeamUtils, FindsInteriorAndEndpointClosestPoints)
+{
+  const std::array<double, 2> nodes = {-1.0, 1.0};
+  const std::array<double, 14> positions = {
+    -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0,
+     1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0};
+  std::array<double, 2> barycentricWeights{};
+  std::array<double, 2> scratchWeights{};
+  std::array<double, 2> scratchDerivatives{};
+  std::array<double, 3> closestPosition{};
+  double closestXi = 0.0;
+  double distanceSquared = 0.0;
+
+  ComputeBarycentricWeights(nodes.data(), 2, barycentricWeights.data());
+  const std::array<double, 3> interiorQuery = {0.25, 2.0, -1.0};
+  FindClosestPointOnBlade(
+    interiorQuery.data(), nodes.data(), positions.data(), 2,
+    barycentricWeights.data(), scratchWeights.data(), scratchDerivatives.data(),
+    closestXi, closestPosition.data(), distanceSquared);
+  EXPECT_NEAR(0.25, closestXi, kTolerance);
+  EXPECT_NEAR(0.25, closestPosition[0], kTolerance);
+  EXPECT_NEAR(5.0, distanceSquared, kTolerance);
+
+  const std::array<double, 3> endpointQuery = {3.0, 2.0, 0.0};
+  FindClosestPointOnBlade(
+    endpointQuery.data(), nodes.data(), positions.data(), 2,
+    barycentricWeights.data(), scratchWeights.data(), scratchDerivatives.data(),
+    closestXi, closestPosition.data(), distanceSquared);
+  EXPECT_DOUBLE_EQ(1.0, closestXi);
+  EXPECT_NEAR(1.0, closestPosition[0], kTolerance);
+  EXPECT_NEAR(8.0, distanceSquared, kTolerance);
+}
+
+} // namespace


### PR DESCRIPTION
- Introduced `CalcLoadsAssembled` class for calculating assembled loads in the FSI context.
- Enhanced `KynemaFMBBase` with methods for mapping beam displacements and loads.
- Added unit tests for `KynemaFMBBase` to validate point and beam load mappings.

## Summary

FSI mapping for beams

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [X] Other (please describe):

## Checklist

The following is included:

- [X] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [X] on CPU Mac + clang
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->


No change made to existing capabilities. So no need to run regression tests. Even for unit tests, only the new ones matter because again no change made to existing capabilities. 

## Additional background

FSI mapping for beams

Issue Number: <!-- Note related issues -->
