### PR TITLE
Prevent SSTAMSChannelEdge FPE

### DIFF
--- a/src/ngp_algorithms/SSTAMSAveragesAlg.C
+++ b/src/ngp_algorithms/SSTAMSAveragesAlg.C
@@ -122,7 +122,7 @@ SSTAMSAveragesAlg::execute()
   const DblType beta_kol_local = beta_kol;
   const DblType aspectRatioSwitch = aspectRatioSwitch_;
   const DblType avgTimeCoeff = avgTimeCoeff_;
-  const DblType minPMbase = std::numeric_limits<DblType>::min();
+  const DblType minPMbase = std::numeric_limits<DblType>::epsilon();
   const auto lengthScaleLimiter = lengthScaleLimiter_;
 
   const bool RANSBelowKs = RANSBelowKs_;

--- a/src/ngp_algorithms/SSTAMSAveragesAlg.C
+++ b/src/ngp_algorithms/SSTAMSAveragesAlg.C
@@ -19,6 +19,8 @@
 #include "utils/AMSUtils.h"
 #include "SolutionOptions.h"
 
+#include <limits>
+
 namespace sierra {
 namespace kynema_ugf {
 
@@ -120,6 +122,7 @@ SSTAMSAveragesAlg::execute()
   const DblType beta_kol_local = beta_kol;
   const DblType aspectRatioSwitch = aspectRatioSwitch_;
   const DblType avgTimeCoeff = avgTimeCoeff_;
+  const DblType minPMbase = std::numeric_limits<DblType>::min();
   const auto lengthScaleLimiter = lengthScaleLimiter_;
 
   const bool RANSBelowKs = RANSBelowKs_;
@@ -382,18 +385,20 @@ SSTAMSAveragesAlg::execute()
         }
       }
 
-      // Scale PM first
-      const DblType v2 =
-        1.0 / v2cMu *
-        (tvisc.get(mi, 0) / density.get(mi, 0) / avgTime.get(mi, 0));
-      const DblType PMscale = stk::math::pow(1.5 * beta.get(mi, 0) * v2, -1.5);
-
       // Handle case where tke = 0, should only occur at a wall boundary
       if (tke.get(mi, 0) == 0.0)
         resAdeq.get(mi, 0) = 1.0;
       else if ((RANSBelowKs) && (coords.get(mi, gravity_i) <= k_s)) {
         resAdeq.get(mi, 0) = 1.0;
       } else {
+        // Scale PM first
+        const DblType v2 =
+          1.0 / v2cMu *
+          (tvisc.get(mi, 0) / density.get(mi, 0) / avgTime.get(mi, 0));
+        const DblType PMbase =
+          stk::math::max(1.5 * beta.get(mi, 0) * v2, minPMbase);
+        const DblType PMscale = stk::math::pow(PMbase, -1.5);
+
         for (int i = 0; i < kynema_ugf_ngp::NDimMax; ++i)
           for (int j = 0; j < kynema_ugf_ngp::NDimMax; ++j)
             PM[i][j] = PM[i][j] * PMscale;

--- a/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
+++ b/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
@@ -154,14 +154,15 @@ MomentumSSTAMSForcingNodeKernel::execute(
                   (smallCl_ - forceCl_)) *
     stk::math::pow(beta * tke, 1.5) / epsSafe;
   length = stk::math::max(
-    length,
-    Ceta_ * (stk::math::pow(mu / rhoSafe, 0.75) / stk::math::pow(epsSafe, 0.25)));
+    length, Ceta_ * (stk::math::pow(mu / rhoSafe, 0.75) /
+                     stk::math::pow(epsSafe, 0.25)));
 
-  const NodeKernelTraits::DblType lengthY = stk::math::max(
-    stk::math::min(length, wallDist), 0.0);
+  const NodeKernelTraits::DblType lengthY =
+    stk::math::max(stk::math::min(length, wallDist), 0.0);
 
   NodeKernelTraits::DblType T_beta = beta * tke / epsSafe;
-  T_beta = stk::math::max(T_beta, Ct_ * stk::math::sqrt(mu / rhoSafe / epsSafe));
+  T_beta =
+    stk::math::max(T_beta, Ct_ * stk::math::sqrt(mu / rhoSafe / epsSafe));
   T_beta = blT_ * T_beta;
 
   // FIXME : Make this aware of wall direction, for now it is

--- a/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
+++ b/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
@@ -14,6 +14,7 @@
 #include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 #include <SimdInterface.h>
+#include <limits>
 
 namespace sierra {
 namespace kynema_ugf {
@@ -140,6 +141,10 @@ MomentumSSTAMSForcingNodeKernel::execute(
   }
 
   const NodeKernelTraits::DblType eps = betaStar_ * tke * sdr;
+  const NodeKernelTraits::DblType minDenom =
+    std::numeric_limits<NodeKernelTraits::DblType>::min();
+  const NodeKernelTraits::DblType rhoSafe = stk::math::max(rho, minDenom);
+  const NodeKernelTraits::DblType epsSafe = stk::math::max(eps, minDenom);
 
   const NodeKernelTraits::DblType smallCl_ = 2.0;
   const NodeKernelTraits::DblType clOffset_ = 0.2;
@@ -147,15 +152,16 @@ MomentumSSTAMSForcingNodeKernel::execute(
   NodeKernelTraits::DblType length =
     (forceCl_ + (1.0 - stk::math::max(beta, 1.0 - clOffset_)) / clOffset_ *
                   (smallCl_ - forceCl_)) *
-    stk::math::pow(beta * tke, 1.5) / eps;
+    stk::math::pow(beta * tke, 1.5) / epsSafe;
   length = stk::math::max(
     length,
-    Ceta_ * (stk::math::pow(mu / rho, 0.75) / stk::math::pow(eps, 0.25)));
+    Ceta_ * (stk::math::pow(mu / rhoSafe, 0.75) / stk::math::pow(epsSafe, 0.25)));
 
-  const NodeKernelTraits::DblType lengthY = stk::math::min(length, wallDist);
+  const NodeKernelTraits::DblType lengthY = stk::math::max(
+    stk::math::min(length, wallDist), 0.0);
 
-  NodeKernelTraits::DblType T_beta = beta * tke / eps;
-  T_beta = stk::math::max(T_beta, Ct_ * stk::math::sqrt(mu / rho / eps));
+  NodeKernelTraits::DblType T_beta = beta * tke / epsSafe;
+  T_beta = stk::math::max(T_beta, Ct_ * stk::math::sqrt(mu / rhoSafe / epsSafe));
   T_beta = blT_ * T_beta;
 
   // FIXME : Make this aware of wall direction, for now it is
@@ -196,9 +202,10 @@ MomentumSSTAMSForcingNodeKernel::execute(
                                  stk::math::sin(yarg) * stk::math::cos(zarg);
 
   // Now we calculate the scaling of the initial field
-  const NodeKernelTraits::DblType v2 = tvisc * betaStar_ * sdr / (cMu_ * rho);
+  const NodeKernelTraits::DblType v2 =
+    tvisc * betaStar_ * sdr / (cMu_ * rhoSafe);
   const NodeKernelTraits::DblType F_target =
-    forceFactor_ * stk::math::sqrt(beta * v2) / T_beta;
+    forceFactor_ * stk::math::sqrt(stk::math::max(beta * v2, 0.0)) / T_beta;
 
   const NodeKernelTraits::DblType prod_r_temp =
     (F_target * dt_) * (hX * fluctU[0] + hY * fluctU[1] + hZ * fluctU[2]);
@@ -211,7 +218,7 @@ MomentumSSTAMSForcingNodeKernel::execute(
     stk::math::if_then_else(prod_r_abs >= 1.0e-15, prod_r_temp, 0.0);
 
   const NodeKernelTraits::DblType b_kol =
-    stk::math::min(blKol_ * stk::math::sqrt(mu * eps / rho) / tke, 1.0);
+    stk::math::min(blKol_ * stk::math::sqrt(mu * epsSafe / rhoSafe) / tke, 1.0);
 
   const NodeKernelTraits::DblType bhat = stk::math::if_then_else(
     (1.0 - b_kol) > 0.0, (1.0 - beta) / (1.0 - b_kol), 10000.0);

--- a/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
+++ b/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
@@ -219,13 +219,16 @@ MomentumSSTAMSForcingNodeKernel::execute(
 
   const NodeKernelTraits::DblType b_kol =
     stk::math::min(blKol_ * stk::math::sqrt(mu * epsSafe / rhoSafe) / tke, 1.0);
+  NodeKernelTraits::DblType bhat = 10000.0;
+  if ((1.0 - b_kol) > 0.0) {
+    bhat = (1.0 - beta) / (1.0 - b_kol);
+  }
 
-  const NodeKernelTraits::DblType bhat = stk::math::if_then_else(
-    (1.0 - b_kol) > 0.0, (1.0 - beta) / (1.0 - b_kol), 10000.0);
+  const NodeKernelTraits::DblType avgResAdeqSafe =
+    stk::math::max(stk::math::min(avgResAdeq, 1.0), minDenom);
 
   NodeKernelTraits::DblType C_F_tmp =
-    -1.0 * stk::math::tanh(
-             1.0 - 1.0 / stk::math::sqrt(stk::math::min(avgResAdeq, 1.0)));
+    -1.0 * stk::math::tanh(1.0 - 1.0 / stk::math::sqrt(avgResAdeqSafe));
 
   C_F_tmp =
     C_F_tmp *

--- a/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
+++ b/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
@@ -142,7 +142,7 @@ MomentumSSTAMSForcingNodeKernel::execute(
 
   const NodeKernelTraits::DblType eps = betaStar_ * tke * sdr;
   const NodeKernelTraits::DblType minDenom =
-    std::numeric_limits<NodeKernelTraits::DblType>::min();
+    std::numeric_limits<NodeKernelTraits::DblType>::epsilon();
   const NodeKernelTraits::DblType rhoSafe = stk::math::max(rho, minDenom);
   const NodeKernelTraits::DblType epsSafe = stk::math::max(eps, minDenom);
 

--- a/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
@@ -340,3 +340,42 @@ TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing)
   // unit_test_kernel_utils::expect_all_near<24>(
   //   helperObjs.linsys->lhs_, 0.0, 1.0e-12);
 }
+
+TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing_zero_wall_inputs)
+{
+  if (bulk_->parallel_size() > 1)
+    return;
+
+  fill_mesh_and_init_fields();
+
+  stk::mesh::field_fill(0.0, *tke_);
+  stk::mesh::field_fill(0.0, *sdr_);
+  stk::mesh::field_fill(0.0, *tvisc_);
+  stk::mesh::field_fill(0.0, *minDist_);
+
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.initialize_turbulence_constants();
+  solnOpts_.eastVector_ = {1.0, 0.0, 0.0};
+  solnOpts_.northVector_ = {0.0, 1.0, 0.0};
+
+  unit_test_utils::NodeHelperObjects helperObjs(
+    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+
+  helperObjs.nodeAlg
+    ->add_kernel<sierra::kynema_ugf::MomentumSSTAMSForcingNodeKernel>(
+      *bulk_, solnOpts_);
+
+  sierra::kynema_ugf::TimeIntegrator timeIntegrator;
+  timeIntegrator.currentTime_ = 0.0;
+  timeIntegrator.timeStepN_ = 0.1;
+  timeIntegrator.timeStepNm1_ = 0.1;
+  timeIntegrator.gamma1_ = 1.0;
+  timeIntegrator.gamma2_ = -1.0;
+  timeIntegrator.gamma3_ = 0.0;
+  helperObjs.realm.timeIntegrator_ = &timeIntegrator;
+
+  helperObjs.execute();
+
+  unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, 0.0, 1.0e-12);
+}

--- a/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
@@ -379,7 +379,8 @@ TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing_zero_wall_inputs)
 
   helperObjs.execute();
 
-  unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, 0.0, 1.0e-12);
+  unit_test_kernel_utils::expect_all_near(
+    helperObjs.linsys->rhs_, 0.0, 1.0e-12);
 }
 
 TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing_finite_at_limits)

--- a/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
@@ -15,6 +15,8 @@
 #include "node_kernels/TKESSTAMSNodeKernel.h"
 #include "node_kernels/MomentumSSTAMSForcingNodeKernel.h"
 
+#include <cmath>
+
 namespace {
 namespace hex8_golds {
 namespace tke_ams {
@@ -378,4 +380,43 @@ TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing_zero_wall_inputs)
   helperObjs.execute();
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, 0.0, 1.0e-12);
+}
+
+TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing_finite_at_limits)
+{
+  if (bulk_->parallel_size() > 1)
+    return;
+
+  fill_mesh_and_init_fields();
+
+  stk::mesh::field_fill(1.0e-12, *tke_);
+  stk::mesh::field_fill(1.0e12, *sdr_);
+  stk::mesh::field_fill(0.0, *avgResAdeq_);
+
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.initialize_turbulence_constants();
+  solnOpts_.eastVector_ = {1.0, 0.0, 0.0};
+  solnOpts_.northVector_ = {0.0, 1.0, 0.0};
+
+  unit_test_utils::NodeHelperObjects helperObjs(
+    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+
+  helperObjs.nodeAlg
+    ->add_kernel<sierra::kynema_ugf::MomentumSSTAMSForcingNodeKernel>(
+      *bulk_, solnOpts_);
+
+  sierra::kynema_ugf::TimeIntegrator timeIntegrator;
+  timeIntegrator.currentTime_ = 0.0;
+  timeIntegrator.timeStepN_ = 0.1;
+  timeIntegrator.timeStepNm1_ = 0.1;
+  timeIntegrator.gamma1_ = 1.0;
+  timeIntegrator.gamma2_ = -1.0;
+  timeIntegrator.gamma3_ = 0.0;
+  helperObjs.realm.timeIntegrator_ = &timeIntegrator;
+
+  helperObjs.execute();
+
+  for (unsigned i = 0; i < helperObjs.linsys->rhs_.extent(0); ++i)
+    ASSERT_TRUE(std::isfinite(helperObjs.linsys->rhs_(i)));
 }

--- a/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
@@ -418,6 +418,8 @@ TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing_finite_at_limits)
 
   helperObjs.execute();
 
-  for (unsigned i = 0; i < helperObjs.linsys->rhs_.extent(0); ++i)
-    ASSERT_TRUE(std::isfinite(helperObjs.linsys->rhs_(i)));
+  auto rhsHost = Kokkos::create_mirror_view_and_copy(
+    Kokkos::HostSpace(), helperObjs.linsys->rhs_);
+  for (unsigned i = 0; i < rhsHost.extent(0); ++i)
+    ASSERT_TRUE(std::isfinite(rhsHost(i)));
 }


### PR DESCRIPTION
## Summary

Prevent the SSTAMSChannelEdge FPE crash by avoiding evaluation of the SST AMS PM scaling power law on wall nodes and by clamping its base away from zero for degenerate non-wall states.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [x] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
